### PR TITLE
feat: 1차카테고리 검색 / fix: OrderBlueprint 필드 수정

### DIFF
--- a/server/src/main/java/com/onetool/server/TestDataLoader.java
+++ b/server/src/main/java/com/onetool/server/TestDataLoader.java
@@ -29,6 +29,7 @@ public class TestDataLoader implements CommandLineRunner {
                         .downloadLink("https://onetool.com/download")
                         .extension(".exe")
                         .blueprintImg("https://s3.bucket.image.com/")
+                        .categoryId(1L)
                         .build()
         );
         final Blueprint blueprint2 = blueprintRepository.save(
@@ -42,6 +43,7 @@ public class TestDataLoader implements CommandLineRunner {
                         .downloadLink("https://onetool.com/download")
                         .extension(".exe")
                         .blueprintImg("https://s3.bucket.image.com/")
+                        .categoryId(2L)
                         .build()
         );
     }

--- a/server/src/main/java/com/onetool/server/blueprint/Blueprint.java
+++ b/server/src/main/java/com/onetool/server/blueprint/Blueprint.java
@@ -54,22 +54,21 @@ public class Blueprint extends BaseEntity {
     @OneToMany(mappedBy = "blueprint")
     private List<CartBlueprint> cartBlueprints = new ArrayList<>();
 
-    @OneToMany(mappedBy = "blueprint")
-    private List<OrderBlueprint> orderBlueprints = new ArrayList<>();
-
     @Builder
-    public Blueprint(String creatorName, LocalDateTime saleExpiredDate, Long salePrice, BigInteger hits, String program, String extension, String blueprintDetails, String blueprintImg, Long standardPrice, Long categoryId, String blueprintName, String creatorName, String downloadLink) {
-        this.creatorName = creatorName;
-        this.saleExpiredDate = saleExpiredDate;
-        this.salePrice = salePrice;
-        this.hits = hits;
-        this.program = program;
-        this.extension = extension;
-        this.blueprintDetails = blueprintDetails;
-        this.blueprintImg = blueprintImg;
-        this.standardPrice = standardPrice;
-        this.categoryId = categoryId;
+    public Blueprint(String blueprintName, Long categoryId, Long standardPrice, String blueprintImg, String blueprintDetails, String extension, String program, BigInteger hits, Long salePrice, LocalDateTime saleExpiredDate, String creatorName, String downloadLink, OrderBlueprint orderBlueprint, List<CartBlueprint> cartBlueprints) {
         this.blueprintName = blueprintName;
+        this.categoryId = categoryId;
+        this.standardPrice = standardPrice;
+        this.blueprintImg = blueprintImg;
+        this.blueprintDetails = blueprintDetails;
+        this.extension = extension;
+        this.program = program;
+        this.hits = hits;
+        this.salePrice = salePrice;
+        this.saleExpiredDate = saleExpiredDate;
+        this.creatorName = creatorName;
         this.downloadLink = downloadLink;
+        this.orderBlueprint = orderBlueprint;
+        this.cartBlueprints = cartBlueprints;
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/BlueprintRepository.java
+++ b/server/src/main/java/com/onetool/server/blueprint/BlueprintRepository.java
@@ -15,4 +15,7 @@ public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
     @Query(value = "SELECT b FROM Blueprint b WHERE b.blueprintName LIKE %:keyword% OR b.creatorName LIKE %:keyword%")
     Page<Blueprint> findAllNameAndCreatorContaining(String keyword, Pageable pageable);
 
+    @Query(value = "SELECT b FROM Blueprint b WHERE b.categoryId IN " +
+            "(SELECT f.id FROM FirstCategory f WHERE f.name = :category)")
+    Page<Blueprint> findAllByFirstCategory(String category, Pageable pageable);
 }

--- a/server/src/main/java/com/onetool/server/blueprint/BlueprintRepository.java
+++ b/server/src/main/java/com/onetool/server/blueprint/BlueprintRepository.java
@@ -15,7 +15,7 @@ public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
     @Query(value = "SELECT b FROM Blueprint b WHERE b.blueprintName LIKE %:keyword% OR b.creatorName LIKE %:keyword%")
     Page<Blueprint> findAllNameAndCreatorContaining(String keyword, Pageable pageable);
 
-    @Query(value = "SELECT b FROM Blueprint b WHERE b.categoryId IN " +
+    @Query(value = "SELECT b FROM Blueprint b WHERE b.categoryId = " +
             "(SELECT f.id FROM FirstCategory f WHERE f.name = :category)")
     Page<Blueprint> findAllByFirstCategory(String category, Pageable pageable);
 }

--- a/server/src/main/java/com/onetool/server/blueprint/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/BlueprintService.java
@@ -1,6 +1,7 @@
 package com.onetool.server.blueprint;
 
 import com.onetool.server.blueprint.dto.SearchResponse;
+import com.onetool.server.category.FirstCategoryType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -25,6 +27,14 @@ public class BlueprintService {
   
     public Page<SearchResponse> searchNameAndCreatorWithKeyword(String keyword, Pageable pageable) {
         Page<Blueprint> result = blueprintRepository.findAllNameAndCreatorContaining(keyword, pageable);
+        List<SearchResponse> list = result.getContent().stream()
+                .map(SearchResponse::from)
+                .collect(Collectors.toList());
+        return new PageImpl<>(list, pageable, result.getTotalElements());
+    }
+
+    public Page<SearchResponse> findAllByFirstCategory(FirstCategoryType category, Pageable pageable) {
+        Page<Blueprint> result = blueprintRepository.findAllByFirstCategory(category.getType(), pageable);
         List<SearchResponse> list = result.getContent().stream()
                 .map(SearchResponse::from)
                 .collect(Collectors.toList());

--- a/server/src/main/java/com/onetool/server/blueprint/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/SearchController.java
@@ -20,7 +20,7 @@ public class SearchController {
         this.blueprintService = blueprintService;
     }
 
-    @GetMapping("/search")
+    @GetMapping("/blueprint")
     public ResponseEntity searchWithKeyword(
             @RequestParam("s")String keyword,
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable

--- a/server/src/main/java/com/onetool/server/blueprint/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/SearchController.java
@@ -1,6 +1,7 @@
 package com.onetool.server.blueprint;
 
 import com.onetool.server.blueprint.dto.SearchResponse;
+import com.onetool.server.category.FirstCategoryType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,4 +31,11 @@ public class SearchController {
         return ResponseEntity.ok().body(response);
     }
 
+    @GetMapping("/blueprint/building")
+    public ResponseEntity searchBuildingCategory(
+            @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
+    ) {
+        Page<SearchResponse> responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_BUILDING, pageable);
+        return ResponseEntity.ok().body(responses);
+    }
 }

--- a/server/src/main/java/com/onetool/server/category/FirstCategoryType.java
+++ b/server/src/main/java/com/onetool/server/category/FirstCategoryType.java
@@ -1,0 +1,20 @@
+package com.onetool.server.category;
+
+import lombok.Getter;
+
+@Getter
+public enum FirstCategoryType {
+    CATEGORY_BUILDING("building"),
+    CATEGORY_CIVIL("civil"),
+    CATEGORY_INTERIOR("interior"),
+    CATEGORY_MACHINE("machine"),
+    CATEGORY_ELECTRIC("electric"),
+    CATEGORY_ETC("etc");
+
+    private final String type;
+
+    FirstCategoryType(String type) {
+        this.type = type;
+    }
+
+}

--- a/server/src/main/java/com/onetool/server/order/OrderBlueprint.java
+++ b/server/src/main/java/com/onetool/server/order/OrderBlueprint.java
@@ -10,12 +10,13 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity
+@Entity (name = "order_blueprint")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderBlueprint extends BaseEntity {
 
     @Id
+    @Column(name = "order_blueprint_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -24,7 +25,7 @@ public class OrderBlueprint extends BaseEntity {
     private List<Blueprint> blueprints = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "order_id")
+    @JoinColumn(name = "orders_id")
     private Orders order;
 
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -7,7 +7,10 @@ spring.datasource.password=1234
 
 spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.format_sql=true
-#db ??? ??. ?? ??? ?? ? ??
+
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
+
 spring.jpa.hibernate.ddl-auto=create
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+INSERT INTO first_category(id, name) VALUES (1, 'building');
+INSERT INTO first_category(id, name) VALUES (2, 'civil');
+INSERT INTO first_category(id, name) VALUES (3, 'interior');
+INSERT INTO first_category(id, name) VALUES (4, 'machine');
+INSERT INTO first_category(id, name) VALUES (5, 'electric');
+INSERT INTO first_category(id, name) VALUES (6, 'etc');

--- a/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceTest.java
+++ b/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceTest.java
@@ -1,6 +1,7 @@
 package com.onetool.server.blueprint;
 
 import com.onetool.server.blueprint.dto.SearchResponse;
+import com.onetool.server.category.FirstCategoryType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,5 +29,15 @@ public class BlueprintServiceTest {
         Pageable pageable = PageRequest.of(0, 5);
         Page<SearchResponse> response = blueprintService.searchNameAndCreatorWithKeyword(keyword, pageable);
         assertThat(response.getTotalElements()).isEqualTo(2);
+    }
+
+    @DisplayName("building 카테고리를 가진 도면이 잘 나오는지 확인")
+    @Test
+    void search_first_category_building() {
+        FirstCategoryType type = FirstCategoryType.CATEGORY_BUILDING;
+
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<SearchResponse> response = blueprintService.findAllByFirstCategory(type, pageable);
+        assertThat(response.getTotalElements()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
### feat: 
1. 빌딩 카테고리 검색
    - FirstCategoryType을 이용하여 1차 카테고리 enum화
    - 저장된 카테고리를 이용하여 1차 카테고리 검색 비즈니스 로직 구현

### fix:
1. 키워드 기반 검색 엔드포인트 변경
    - /search에서 /blueprint로 변경
2. OrderBlueprint에 Blueprint 필드가 두 개인 문제 해결

