### PR TITLE
feat: 일반 로그인 (Spring Securty + JWT)

### DIFF
--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -2,7 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="false" />
+        <option name="testRunner" value="PLATFORM" />
         <option name="externalProjectPath" value="$PROJECT_DIR$/server" />
         <option name="gradleJvm" value="corretto-17" />
         <option name="modules">

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="GroovyAssignabilityCheck" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/server" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/backend.iml" filepath="$PROJECT_DIR$/.idea/backend.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/server.main.iml" filepath="$PROJECT_DIR$/.idea/modules/server.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/server.main.iml
+++ b/.idea/modules/server.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../server/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../server/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/backend_submodule" vcs="Git" />
   </component>
 </project>

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+/src/main/resources/application-dev.properties
 
 ### STS ###
 .apt_generated

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -34,8 +34,25 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.security:spring-security-web:6.3.1'
+	implementation 'org.springframework.security:spring-security-config:6.3.1'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+processResources.dependsOn('copyModule')
+
+tasks.register('copyModule', Copy) {
+	copy {
+		from './backend_submodule'
+		include "*.properties"
+		into './server/src/main/resources'
+	}
 }

--- a/server/src/main/java/com/onetool/server/blueprint/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/SearchController.java
@@ -78,13 +78,13 @@ public class SearchController {
         return ResponseEntity.ok().body(responses);
     }
 
-    @GetMapping("/blueprint/building")
-    public ResponseEntity searchSecondCategoryOfBuilding(
-            @RequestParam String category,
-            @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
-    ) {
-        Page<SearchResponse> responses = blueprintService.findAllBySecondCategory(
-                FirstCategoryType.CATEGORY_BUILDING, category, pageable);
-        return ResponseEntity.ok().body(responses);
-    }
+//    @GetMapping("/blueprint/building")
+//    public ResponseEntity searchSecondCategoryOfBuilding(
+//            @RequestParam String category,
+//            @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
+//    ) {
+//        Page<SearchResponse> responses = blueprintService.findAllBySecondCategory(
+//                FirstCategoryType.CATEGORY_BUILDING, category, pageable);
+//        return ResponseEntity.ok().body(responses);
+//    }
 }

--- a/server/src/main/java/com/onetool/server/global/auth/AuthorizationProvider.java
+++ b/server/src/main/java/com/onetool/server/global/auth/AuthorizationProvider.java
@@ -1,7 +1,14 @@
 package com.onetool.server.global.auth;
 
+import io.jsonwebtoken.Claims;
+
 public interface AuthorizationProvider {
-    MemberCredential create(MemberAuthContext user);
-    MemberAuthContext parseCredential(MemberCredential token);
+
+    String create(MemberAuthContext context);
+
+    Claims parseClaims(String token);
+
     boolean validateToken(String token);
+
+    public Long getUserId(String token);
 }

--- a/server/src/main/java/com/onetool/server/global/auth/AuthorizationProvider.java
+++ b/server/src/main/java/com/onetool/server/global/auth/AuthorizationProvider.java
@@ -1,0 +1,6 @@
+package com.onetool.server.global.auth;
+
+public interface AuthorizationProvider {
+    UserCredential create(UserAuthContext user);
+    UserAuthContext parseCredential(UserCredential token);
+}

--- a/server/src/main/java/com/onetool/server/global/auth/AuthorizationProvider.java
+++ b/server/src/main/java/com/onetool/server/global/auth/AuthorizationProvider.java
@@ -1,6 +1,7 @@
 package com.onetool.server.global.auth;
 
 public interface AuthorizationProvider {
-    UserCredential create(UserAuthContext user);
-    UserAuthContext parseCredential(UserCredential token);
+    MemberCredential create(MemberAuthContext user);
+    MemberAuthContext parseCredential(MemberCredential token);
+    boolean validateToken(String token);
 }

--- a/server/src/main/java/com/onetool/server/global/auth/CustomAccessDeniedHandler.java
+++ b/server/src/main/java/com/onetool/server/global/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,23 @@
+package com.onetool.server.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        String accept = request.getHeader("Accept");
+
+        if ("application/json".equals(accept)) {
+            response.setStatus(403);
+        }
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/auth/CustomAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/onetool/server/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package com.onetool.server.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.ErrorResponse;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        String accept = request.getHeader("Accept");
+
+        if ("application/json".equals(accept)) {
+            response.setStatus(401);
+        }
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/auth/MemberAuthContext.java
+++ b/server/src/main/java/com/onetool/server/global/auth/MemberAuthContext.java
@@ -1,7 +1,18 @@
 package com.onetool.server.global.auth;
 
-public record MemberAuthContext(
-        String name,
-        String role
-) {
+import lombok.*;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MemberAuthContext {
+    private Long id;
+    private String name;
+    private String role;
+    private String email;
+    private String password;
 }

--- a/server/src/main/java/com/onetool/server/global/auth/MemberAuthContext.java
+++ b/server/src/main/java/com/onetool/server/global/auth/MemberAuthContext.java
@@ -1,6 +1,6 @@
 package com.onetool.server.global.auth;
 
-public record UserAuthContext(
+public record MemberAuthContext(
         String name,
         String role
 ) {

--- a/server/src/main/java/com/onetool/server/global/auth/MemberCredential.java
+++ b/server/src/main/java/com/onetool/server/global/auth/MemberCredential.java
@@ -1,6 +1,6 @@
 package com.onetool.server.global.auth;
 
-public record UserCredential(
+public record MemberCredential(
         String authorization
 ) {
 }

--- a/server/src/main/java/com/onetool/server/global/auth/MemberCredential.java
+++ b/server/src/main/java/com/onetool/server/global/auth/MemberCredential.java
@@ -1,6 +1,0 @@
-package com.onetool.server.global.auth;
-
-public record MemberCredential(
-        String authorization
-) {
-}

--- a/server/src/main/java/com/onetool/server/global/auth/UserAuthContext.java
+++ b/server/src/main/java/com/onetool/server/global/auth/UserAuthContext.java
@@ -1,0 +1,7 @@
+package com.onetool.server.global.auth;
+
+public record UserAuthContext(
+        String name,
+        String role
+) {
+}

--- a/server/src/main/java/com/onetool/server/global/auth/UserCredential.java
+++ b/server/src/main/java/com/onetool/server/global/auth/UserCredential.java
@@ -1,0 +1,6 @@
+package com.onetool.server.global.auth;
+
+public record UserCredential(
+        String authorization
+) {
+}

--- a/server/src/main/java/com/onetool/server/global/auth/filter/JwtAuthFilter.java
+++ b/server/src/main/java/com/onetool/server/global/auth/filter/JwtAuthFilter.java
@@ -1,0 +1,53 @@
+package com.onetool.server.global.auth.filter;
+
+import com.onetool.server.global.auth.jwt.JwtUtil;
+import com.onetool.server.global.exception.MemberNotFoundException;
+import com.onetool.server.member.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        //JWT가 헤더에 있는 경우
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);
+            //JWT 유효성 검증
+            if (jwtUtil.validateToken(token)) {
+                Long userId = jwtUtil.getUserId(token);
+
+                //유저와 토큰 일치 시 userDetails 생성
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(userId.toString());
+
+                if (userDetails != null) {
+                    //UserDetsils, Password, Role -> 접근권한 인증 Token 생성
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                    //현재 Request의 Security Context에 접근권한 설정
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            } else {
+                throw new MemberNotFoundException();
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
+++ b/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
@@ -2,7 +2,6 @@ package com.onetool.server.global.auth.jwt;
 
 import com.onetool.server.global.auth.AuthorizationProvider;
 import com.onetool.server.global.auth.MemberAuthContext;
-import com.onetool.server.global.auth.MemberCredential;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;

--- a/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
+++ b/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
@@ -1,0 +1,59 @@
+package com.onetool.server.global.auth.jwt;
+
+import com.onetool.server.global.auth.AuthorizationProvider;
+import com.onetool.server.global.auth.UserAuthContext;
+import com.onetool.server.global.auth.UserCredential;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtUtil implements AuthorizationProvider {
+
+    private static final String USER_NAME = "name";
+    private static final String USER_ROLE = "role";
+
+    private final String secretKey;
+    private final Long expirationMilliSec;
+
+    public JwtUtil(
+            @Value("${onetool.jwt.secrekey}") String secretKey,
+            @Value("${onetool.jwt.expiration_time}") Long expirationMilliSec
+    ) {
+        this.secretKey = secretKey;
+        this.expirationMilliSec = expirationMilliSec;
+    }
+
+    @Override
+    public UserCredential create(UserAuthContext context) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + expirationMilliSec);
+
+        String tokenValue = Jwts.builder()
+                .claim(USER_NAME, context.name())
+                .claim(USER_ROLE, context.role())
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+        return new UserCredential(tokenValue);
+    }
+
+    @Override
+    public UserAuthContext parseCredential(UserCredential token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey)))
+                .build()
+                .parseClaimsJws(token.authorization())
+                .getBody();
+        return new UserAuthContext(
+                claims.get(USER_NAME, String.class),
+                claims.get(USER_ROLE, String.class)
+        );
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
+++ b/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.security.Key;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 @Slf4j
@@ -19,49 +21,50 @@ public class JwtUtil implements AuthorizationProvider {
     private static final String USER_NAME = "name";
     private static final String USER_ROLE = "role";
 
-    private final String secretKey;
+    private final Key key;
     private final Long expirationMilliSec;
 
     public JwtUtil(
             @Value("${onetool.jwt.secrekey}") String secretKey,
             @Value("${onetool.jwt.expiration_time}") Long expirationMilliSec
     ) {
-        this.secretKey = secretKey;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
         this.expirationMilliSec = expirationMilliSec;
     }
 
     @Override
-    public MemberCredential create(MemberAuthContext context) {
-        Date now = new Date();
-        Date validity = new Date(now.getTime() + expirationMilliSec);
+    public String create(MemberAuthContext context) {
+        Claims claims = Jwts.claims();
+        claims.put("memberId", context.getId());
+        claims.put("email", context.getEmail());
+        claims.put("role", context.getRole());
 
-        String tokenValue = Jwts.builder()
-                .claim(USER_NAME, context.name())
-                .claim(USER_ROLE, context.role())
-                .setIssuedAt(now)
-                .setExpiration(validity)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(expirationMilliSec);
+
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(tokenValidity.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
-        return new MemberCredential(tokenValue);
     }
 
     @Override
-    public MemberAuthContext parseCredential(MemberCredential token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey)))
-                .build()
-                .parseClaimsJws(token.authorization())
-                .getBody();
-        return new MemberAuthContext(
-                claims.get(USER_NAME, String.class),
-                claims.get(USER_ROLE, String.class)
-        );
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
     }
 
     @Override
     public boolean validateToken(String token) {
         try{
-            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch(io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("Invalid JWT Token", e);
@@ -73,5 +76,10 @@ public class JwtUtil implements AuthorizationProvider {
             log.info("JWT claims string is empty.", e);
         }
         return false;
+    }
+
+    @Override
+    public Long getUserId(String token) {
+        return parseClaims(token).get("memberId", Long.class);
     }
 }

--- a/server/src/main/java/com/onetool/server/global/config/PasswordEncoderConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.onetool.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -1,0 +1,13 @@
+package com.onetool.server.global.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+
+@Configuration
+public class SecurityConfig {
+
+}

--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -1,13 +1,56 @@
 package com.onetool.server.global.config;
 
 
+import com.onetool.server.global.auth.CustomAccessDeniedHandler;
+import com.onetool.server.global.auth.CustomAuthenticationEntryPoint;
+import com.onetool.server.global.auth.filter.JwtAuthFilter;
+import com.onetool.server.global.auth.jwt.JwtUtil;
+import com.onetool.server.member.service.CustomUserDetailsService;
+import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@AllArgsConstructor
 public class SecurityConfig {
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
+    private static final String[] AUTH_WHITELIST = {
+        "/users/login/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .headers((headers) -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS
+                ))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling((exceptionHandling) -> exceptionHandling
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .anyRequest().authenticated());
+
+        return http.build();
+    }
 }

--- a/server/src/main/java/com/onetool/server/global/exception/MemberNotFoundException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/MemberNotFoundException.java
@@ -1,7 +1,5 @@
 package com.onetool.server.global.exception;
 
 public class MemberNotFoundException extends RuntimeException {
-    public MemberNotFoundException(String message) {
-        super(message);
-    }
+    public MemberNotFoundException(){}
 }

--- a/server/src/main/java/com/onetool/server/global/exception/MemberNotFoundException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/MemberNotFoundException.java
@@ -1,0 +1,7 @@
+package com.onetool.server.global.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/Member.java
+++ b/server/src/main/java/com/onetool/server/member/Member.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class Member extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
@@ -37,7 +37,7 @@ public class Member extends BaseEntity {
     @Column(name = "phone_num") @NotNull @Size(min = 10, max = 11)
     private String phoneNum;
 
-    @Column(name = "role") @ColumnDefault("'회원'")
+    @Column(name = "user_role")
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
@@ -60,7 +60,7 @@ public class Member extends BaseEntity {
     private Cart cart;
 
     @Builder
-    private Member(String password, String email, String name, LocalDate birthDate, String phoneNum, UserRole role, String field, boolean isNative, boolean serviceAccept, String platformType, List<QnaBoard> qnaBoards, Cart cart) {
+    public Member(String password, String email, String name, LocalDate birthDate, String phoneNum, UserRole role, String field, boolean isNative, boolean serviceAccept, String platformType, List<QnaBoard> qnaBoards, Cart cart) {
         this.password = password;
         this.email = email;
         this.name = name;
@@ -74,10 +74,4 @@ public class Member extends BaseEntity {
         this.qnaBoards = qnaBoards;
         this.cart = cart;
     }
-    // TODO builder패턴 완성하기
-    /*    public static Member createMember(MemberRequest reuqest){
-            return Member.builder()
-                    .
-        }
-    */
 }

--- a/server/src/main/java/com/onetool/server/member/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/MemberController.java
@@ -1,0 +1,29 @@
+package com.onetool.server.member;
+
+import com.onetool.server.global.auth.MemberCredential;
+import com.onetool.server.member.dto.LoginRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/users")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping("login")
+    public ResponseEntity<String> login(
+            @Valid @RequestBody LoginRequest request
+    ) {
+        String token = memberService.login(request);
+        return ResponseEntity.ok(token);
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/MemberController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/users")
+@Controller
 public class MemberController {
 
     private final MemberService memberService;
@@ -19,7 +19,7 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    @PostMapping("login")
+    @PostMapping("/users/login")
     public ResponseEntity<String> login(
             @Valid @RequestBody LoginRequest request
     ) {

--- a/server/src/main/java/com/onetool/server/member/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/MemberController.java
@@ -1,14 +1,11 @@
 package com.onetool.server.member;
 
-import com.onetool.server.global.auth.MemberCredential;
 import com.onetool.server.member.dto.LoginRequest;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
 
 @Controller
 public class MemberController {

--- a/server/src/main/java/com/onetool/server/member/MemberControllerAdvice.java
+++ b/server/src/main/java/com/onetool/server/member/MemberControllerAdvice.java
@@ -1,0 +1,15 @@
+package com.onetool.server.member;
+
+import com.onetool.server.global.exception.MemberNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class MemberControllerAdvice {
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ResponseEntity handleNotFoundMemberException(MemberNotFoundException e) {
+        return ResponseEntity.badRequest().body("유저를 찾을 수 없습니다.");
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/MemberRepository.java
+++ b/server/src/main/java/com/onetool/server/member/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.onetool.server.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/server/src/main/java/com/onetool/server/member/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/MemberService.java
@@ -1,7 +1,6 @@
 package com.onetool.server.member;
 
 import com.onetool.server.global.auth.MemberAuthContext;
-import com.onetool.server.global.auth.MemberCredential;
 import com.onetool.server.global.auth.jwt.JwtUtil;
 import com.onetool.server.global.exception.MemberNotFoundException;
 import com.onetool.server.member.dto.LoginRequest;

--- a/server/src/main/java/com/onetool/server/member/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/MemberService.java
@@ -1,0 +1,40 @@
+package com.onetool.server.member;
+
+import com.onetool.server.global.auth.MemberAuthContext;
+import com.onetool.server.global.auth.MemberCredential;
+import com.onetool.server.global.auth.jwt.JwtUtil;
+import com.onetool.server.global.exception.MemberNotFoundException;
+import com.onetool.server.member.dto.LoginRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder encoder;
+
+    public String login(LoginRequest request) {
+        String email = request.getEmail();
+        String password = request.getPassword();
+
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new MemberNotFoundException("이메일이 존재하지 않습니다."));
+        if(!encoder.matches(password, member.getPassword())){
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        MemberAuthContext context = new MemberAuthContext(
+                member.getName(),
+                member.getRole().name()
+        );
+
+        MemberCredential memberCredential = jwtUtil.create(context);
+        return memberCredential.authorization();
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/MemberService.java
@@ -6,6 +6,7 @@ import com.onetool.server.global.auth.jwt.JwtUtil;
 import com.onetool.server.global.exception.MemberNotFoundException;
 import com.onetool.server.member.dto.LoginRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class MemberService {
 
     private final JwtUtil jwtUtil;
@@ -24,17 +26,22 @@ public class MemberService {
         String email = request.getEmail();
         String password = request.getPassword();
 
-        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new MemberNotFoundException("이메일이 존재하지 않습니다."));
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        log.info("============== 로그인 유저 정보 ===============");
+        log.info(member.toString());
+
         if(!encoder.matches(password, member.getPassword())){
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
-        MemberAuthContext context = new MemberAuthContext(
-                member.getName(),
-                member.getRole().name()
-        );
+        MemberAuthContext context = MemberAuthContext.builder()
+                .id(member.getId())
+                .role(member.getRole().name())
+                .name(member.getName())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .build();
 
-        MemberCredential memberCredential = jwtUtil.create(context);
-        return memberCredential.authorization();
+        return jwtUtil.create(context);
     }
 }

--- a/server/src/main/java/com/onetool/server/member/domain/CustomUserDetails.java
+++ b/server/src/main/java/com/onetool/server/member/domain/CustomUserDetails.java
@@ -1,0 +1,64 @@
+package com.onetool.server.member.domain;
+
+import com.onetool.server.global.auth.MemberAuthContext;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final MemberAuthContext context;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_" + context.getRole());
+
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return context.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+
+
+
+
+}

--- a/server/src/main/java/com/onetool/server/member/dto/LoginMember.java
+++ b/server/src/main/java/com/onetool/server/member/dto/LoginMember.java
@@ -1,0 +1,22 @@
+package com.onetool.server.member.dto;
+
+import com.onetool.server.member.UserRole;
+import lombok.Builder;
+
+public record LoginMember(
+        Long id,
+        String email,
+        String name,
+        String password,
+        UserRole role
+) {
+
+    @Builder
+    public LoginMember(Long id, String email, String name, String password, UserRole role) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.password = password;
+        this.role = role;
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/dto/LoginRequest.java
+++ b/server/src/main/java/com/onetool/server/member/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.onetool.server.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotNull(message = "이메일이 null 일 수 없습니다.")
+    @Email
+    private String email;
+
+    @NotNull(message = "비밀번호는 null 일 수 없습니다.")
+    private String password;
+}

--- a/server/src/main/java/com/onetool/server/member/service/CustomUserDetailsService.java
+++ b/server/src/main/java/com/onetool/server/member/service/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.onetool.server.member.service;
+
+import com.onetool.server.global.auth.MemberAuthContext;
+import com.onetool.server.member.Member;
+import com.onetool.server.member.MemberRepository;
+import com.onetool.server.member.domain.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Member member = memberRepository.findById(Long.parseLong(id))
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저가 없습니다."));
+
+        MemberAuthContext context = MemberAuthContext.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .role(member.getRole().name())
+                .password(member.getPassword())
+                .name(member.getName())
+                .build();
+
+        return new CustomUserDetails(context);
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -14,3 +14,5 @@ spring.jpa.defer-datasource-initialization=true
 spring.jpa.hibernate.ddl-auto=create
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+spring.profiles.active=dev

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -15,28 +15,28 @@ INSERT INTO second_category (id, first_category_id, name)
 
 # 토목
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (1, 2, '도로');
+    VALUE (3, 2, '도로');
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (2, 2, '교량');
+    VALUE (4, 2, '교량');
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (3, 2, '터널');
+    VALUE (5, 2, '터널');
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (4, 2, '댐/수자원');
+    VALUE (6, 2, '댐/수자원');
 
 # 인테리어
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (1, 3, '주거');
+    VALUE (7, 3, '주거');
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (2, 3, '상업');
+    VALUE (8, 3, '상업');
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (3, 3, '가구/집기');
+    VALUE (9, 3, '가구/집기');
 
 # 기계
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (1, 4, '기계부품');
+    VALUE (10, 4, '기계부품');
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (2, 4, '설비');
+    VALUE (11, 4, '설비');
 
 # 전기
 INSERT INTO second_category (id, first_category_id, name)
-    VALUE (1, 5, '전기');
+    VALUE (12, 5, '전기');


### PR DESCRIPTION
## 🔎 작업 내용

- jwt secretket와 만료시간을 저장할 `Submodule` 추가
- Spring Security 추가
- Jwt용 Filter 추가
- Security Config 추가
    - WHITELIST_URL을 통해 인증이 필요없는 url 설정

1. `MemberAuthContext`: 유저의 인증을 위한 정보를 저장
2. `JwtAuthFilter`: 요청에 담긴 jwt를 검증하여 userDetail 생성 및 현재 요청의 접근 허용
3. `JwtUtil`: Jwt 토큰 생성 및 Validation
4. `AuthorizationProvider`: JwtUtil의 인터페이스
5. `CustomAccessDeniedHandler`: 액서스 거부 시 핸들러 (SecurityConfig에서 설정)
6. `CustomAuthenticationEntryPoint`: 엔트리 포인트의 인증 예외처리
7. `SecurityConfig`: 스프링 시큐리티 설정
8. `MemberControllerAdvice`: Member 도메인 컨트롤러의 예외처리 통합 관리

<br/>

## 🔧 앞으로의 과제

- 일반 회원가입 기능 추가

  <br/>

## ➕ 이슈 링크


<br/>