### PR TITLE
[feat] global exception 및 api 응답 형식 통일

### DIFF
--- a/server/src/main/java/com/onetool/server/global/exception/BaseException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/BaseException.java
@@ -1,0 +1,17 @@
+package com.example.exception.common;
+
+import com.example.exception.common.codes.BaseCode;
+import com.example.exception.common.reason.Reason.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseException extends RuntimeException {
+
+    private BaseCode code;
+
+    public ReasonDto getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/BaseResponse.java
+++ b/server/src/main/java/com/onetool/server/global/exception/BaseResponse.java
@@ -1,0 +1,39 @@
+package com.example.exception.common;
+
+import com.example.exception.common.codes.SuccessCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class BaseResponse<T> {
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    /**
+     * 요청 성공 시 응답 생성
+     */
+
+    public static<T> BaseResponse<T> onSuccess(T result){
+        return new BaseResponse<>(true, SuccessCode.SUCCESS.getCode(), SuccessCode.SUCCESS.getMessage(), result);
+    }
+
+    public static <T> BaseResponse<T> of(SuccessCode code, T result){
+        return new BaseResponse<>(true, code.getCode() , code.getMessage(), result);
+    }
+
+    /**
+     * 요청 실패 시 응답 생성
+     */
+    public static <T> BaseResponse<T> onFailure(String code, String message, T data) {
+        return new BaseResponse<>(false, code, message, data);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/WebErrorController.java
+++ b/server/src/main/java/com/onetool/server/global/exception/WebErrorController.java
@@ -1,0 +1,31 @@
+package com.example.exception.controller;
+
+import com.example.exception.common.BaseResponse;
+import com.example.exception.common.codes.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@RestController
+@Slf4j
+public class WebErrorController implements ErrorController {
+
+    @RequestMapping("/error")
+    public BaseResponse<?> handleError(HttpServletRequest request) throws NoHandlerFoundException {
+        log.info(request.getRequestURI());
+        Object status = request.getAttribute("jakarta.servlet.error.status_code");
+        if (status != null) {
+            int statusCode = Integer.parseInt(status.toString());
+            if (statusCode == HttpStatus.NOT_FOUND.value()) {
+                throw new NoHandlerFoundException("GET", request.getRequestURI(), HttpHeaders.EMPTY);
+            }
+        }
+        return BaseResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR.getCode(), ErrorCode.INTERNAL_SERVER_ERROR.getMessage(), null);
+    }
+
+}

--- a/server/src/main/java/com/onetool/server/global/exception/codes/BaseCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/BaseCode.java
@@ -1,0 +1,7 @@
+package com.example.exception.common.codes;
+
+import com.example.exception.common.reason.Reason;
+
+public interface BaseCode {
+    public Reason.ReasonDto getReasonHttpStatus();
+}

--- a/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
@@ -1,0 +1,96 @@
+package com.example.exception.common.codes;
+
+import com.example.exception.common.reason.Reason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements BaseCode {
+
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    /**
+     * ******************************* Global Error CodeList ***************************************
+     * HTTP Status Code
+     * 400 : Bad Request
+     * 401 : Unauthorized
+     * 403 : Forbidden
+     * 404 : Not Found
+     * 500 : Internal Server Error
+     * *********************************************************************************************
+     */
+    // 잘못된 서버 요청
+    BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "G001", "Bad Request Exception"),
+
+    // @RequestBody 데이터 미 존재
+    REQUEST_BODY_MISSING_ERROR(HttpStatus.BAD_REQUEST, "G002", "Required request body is missing"),
+
+    // 유효하지 않은 타입
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "G003", " Invalid Type Value"),
+
+    // Request Parameter 로 데이터가 전달되지 않을 경우
+    MISSING_REQUEST_PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "G004", "Missing Servlet RequestParameter Exception"),
+
+    // 입력/출력 값이 유효하지 않음
+    IO_ERROR(HttpStatus.BAD_REQUEST, "G005", "I/O Exception"),
+
+    // com.google.gson JSON 파싱 실패
+    JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "G006", "JsonParseException"),
+
+    // com.fasterxml.jackson.core Processing Error
+    JACKSON_PROCESS_ERROR(HttpStatus.BAD_REQUEST, "G007", "com.fasterxml.jackson.core Exception"),
+
+    // 권한이 없음
+    FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "G008", "Forbidden Exception"),
+
+    // 서버로 요청한 리소스가 존재하지 않음
+    NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "G009", "Not Found Exception"),
+
+    // NULL Point Exception 발생
+    NULL_POINT_ERROR(HttpStatus.NOT_FOUND, "G010", "Null Point Exception"),
+
+    // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
+    NOT_VALID_ERROR(HttpStatus.NOT_FOUND, "G011", "handle Validation Exception"),
+
+    // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
+    NOT_VALID_HEADER_ERROR(HttpStatus.NOT_FOUND, "G012", "Header에 데이터가 존재하지 않는 경우 "),
+
+    // 4xx : client error
+
+    //자잘한 에러
+    SEARCH_KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "KEYWORD-0000", "검색어는 3글자부터 입력하세요."),
+
+    //바인딩 에러
+    BINDING_ERROR(HttpStatus.BAD_REQUEST, "BINDING-0000", "바인딩에 실패했습니다."),
+
+    //로그인 에러
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "LOGIN-0001", "이메일이 잘못됨"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-0000", "잘못된 요청입니다."),
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "COMMON-0002", "이미 존재하는 회원입니다."),
+    /*
+    *
+    *
+    * */
+
+    // 5xx : server error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER-0000", "서버 에러");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    public Reason.ReasonDto getReasonHttpStatus() {
+        return Reason.ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/codes/SuccessCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/SuccessCode.java
@@ -1,0 +1,22 @@
+package com.example.exception.common.codes;
+
+import com.example.exception.common.reason.Reason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode implements BaseCode{
+
+    SUCCESS(HttpStatus.OK, "SUCCESS-0000", "요청에 성공하였습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public Reason.ReasonDto getReasonHttpStatus() {
+        return null;
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/codes/reason/Reason.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/reason/Reason.java
@@ -1,0 +1,19 @@
+package com.example.exception.common.reason;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+public class Reason {
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReasonDto{
+        HttpStatus httpStatus;
+        String code;
+        String message;
+        Boolean isSuccess;
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/howToUse/TempController.java
+++ b/server/src/main/java/com/onetool/server/global/exception/howToUse/TempController.java
@@ -1,0 +1,25 @@
+package com.example.exception.controller;
+
+import com.example.exception.common.BaseResponse;
+import com.example.exception.service.TempService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import com.example.exception.temp.TempRequest.*;
+
+@RestController
+@RequiredArgsConstructor
+public class TempController {
+
+    private final TempService tempService;
+
+    @GetMapping("/binding")
+    public BaseResponse<?> bindingTest(@Validated @RequestBody TempLoginRequest request){
+        return BaseResponse.onSuccess(tempService.logic(request));
+    }
+
+    @GetMapping("/search")
+    public BaseResponse<?> validationTest(@RequestParam String keyword){
+        return BaseResponse.onSuccess(tempService.searchEngine(keyword));
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/howToUse/service/TempService.java
+++ b/server/src/main/java/com/onetool/server/global/exception/howToUse/service/TempService.java
@@ -1,0 +1,10 @@
+package com.example.exception.service;
+
+import com.example.exception.temp.TempRequest.*;
+
+public interface TempService {
+    String logic(TempLoginRequest data);
+    void errorCheck(TempLoginRequest data);
+    String searchEngine(String keyword);
+    void errorCheck(String keyword);
+}

--- a/server/src/main/java/com/onetool/server/global/exception/howToUse/service/TempServiceImpl.java
+++ b/server/src/main/java/com/onetool/server/global/exception/howToUse/service/TempServiceImpl.java
@@ -1,0 +1,36 @@
+package com.example.exception.service;
+
+import static com.example.exception.common.codes.ErrorCode.*;
+import com.example.exception.handler.MyExceptionHandler;
+import com.example.exception.temp.TempRequest.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TempServiceImpl implements TempService {
+
+    public String logic(TempLoginRequest data) {
+        log.info("service in");
+        errorCheck(data);
+        return "아 시발 하기 싫어";
+    }
+
+    public String searchEngine(String keyword) {
+        log.info("keyword : {}", keyword);
+        errorCheck(keyword);
+        return "I wanna go home";
+    }
+
+
+    public void errorCheck(String keyword) {
+        if(keyword.length() < 3)
+            throw new MyExceptionHandler(SEARCH_KEYWORD_TOO_SHORT);
+    }
+
+    public void errorCheck(TempLoginRequest data) {
+        if(data.getPassword().equals("1234")){
+            throw new MyExceptionHandler(EXIST_EMAIL);
+        }
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/howToUse/temp/TempConverter.java
+++ b/server/src/main/java/com/onetool/server/global/exception/howToUse/temp/TempConverter.java
@@ -1,0 +1,10 @@
+package com.example.exception.temp;
+
+public class TempConverter {
+
+    public static TempResponse.TempTestDTO toTempTestDTO(){
+        return TempResponse.TempTestDTO.builder()
+                .testString("This is Test!")
+                .build();
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/howToUse/temp/TempRequest.java
+++ b/server/src/main/java/com/onetool/server/global/exception/howToUse/temp/TempRequest.java
@@ -1,0 +1,23 @@
+package com.example.exception.temp;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TempRequest {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TempLoginRequest{
+        @NotBlank(message = "이메일을 입력해주세요")
+        @Email(message = "이메일을 형식에 맞게 다시 입력해주세요.")
+        private String email;
+
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        private String password;
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/howToUse/temp/TempResponse.java
+++ b/server/src/main/java/com/onetool/server/global/exception/howToUse/temp/TempResponse.java
@@ -1,0 +1,16 @@
+package com.example.exception.temp;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TempResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TempTestDTO{
+        String testString;
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -1,0 +1,173 @@
+package com.example.exception.handler;
+
+import com.example.exception.common.BaseException;
+import com.example.exception.common.BaseResponse;
+import com.example.exception.common.codes.ErrorCode;
+import static com.example.exception.common.reason.Reason.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.io.IOException;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice {
+
+    /**
+     * 바인딩 에러 처리
+     * @param e
+     * @return
+     */
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+        BaseResponse<?> baseResponse = BaseResponse.onFailure(ErrorCode.BINDING_ERROR.getCode(), message, null);
+        return handleExceptionInternal(baseResponse);
+    }
+
+    /**
+     * 서버 에러
+     * @param e
+     * @return
+     */
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e) {
+        ErrorCode errorCode = ErrorCode._INTERNAL_SERVER_ERROR;
+        BaseResponse<?> baseResponse = BaseResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null);
+        return handleExceptionInternal(baseResponse);
+    }
+
+    /**
+     * 클라이언트 에러
+     * @param generalException
+     * @return
+     */
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<Object> onThrowException(BaseException generalException) {
+        ReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        BaseResponse<?> baseResponse = BaseResponse.onFailure(errorReasonHttpStatus.getCode(), errorReasonHttpStatus.getMessage(), null);
+        return handleExceptionInternal(baseResponse);
+    }
+
+    /**
+     * [Exception] API 호출 시 'Header' 내에 데이터 값이 유효하지 않은 경우
+     *
+     * @param ex MissingRequestHeaderException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ResponseEntity<Object> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
+        log.error("MissingRequestHeaderException", ex);
+
+        return handleExceptionInternal(ErrorCode.REQUEST_BODY_MISSING_ERROR);
+    }
+
+    /**
+     * [Exception] 클라이언트에서 Body로 '객체' 데이터가 넘어오지 않았을 경우
+     *
+     * @param ex HttpMessageNotReadableException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler
+    public ResponseEntity<Object> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException ex) {
+        log.info("HttpMessageNotReadableException", ex);
+        return handleExceptionInternal(ErrorCode.REQUEST_BODY_MISSING_ERROR);
+    }
+
+    /**
+     * [Exception] 클라이언트에서 request로 '파라미터로' 데이터가 넘어오지 않았을 경우
+     *
+     * @param ex MissingServletRequestParameterException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<Object> handleMissingRequestHeaderExceptionException(
+            MissingServletRequestParameterException ex) {
+        log.error("handleMissingServletRequestParameterException", ex);
+        return handleExceptionInternal(ErrorCode.MISSING_REQUEST_PARAMETER_ERROR);
+    }
+
+
+    /**
+     * [Exception] 잘못된 서버 요청일 경우 발생한 경우
+     *
+     * @param e HttpClientErrorException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(HttpClientErrorException.BadRequest.class)
+    protected ResponseEntity<Object> handleBadRequestException(HttpClientErrorException e) {
+        log.error("HttpClientErrorException.BadRequest", e);
+        return handleExceptionInternal(ErrorCode.BAD_REQUEST_ERROR);
+    }
+
+
+    /**
+     * [Exception] NULL 값이 발생한 경우
+     *
+     * @param e NullPointerException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(NullPointerException.class)
+    protected ResponseEntity<Object> handleNullPointerException(NullPointerException e) {
+        log.error("handleNullPointerException", e);
+        return handleExceptionInternal(ErrorCode.NULL_POINT_ERROR);
+    }
+
+    /**
+     * Input / Output 내에서 발생한 경우
+     *
+     * @param ex IOException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(IOException.class)
+    protected ResponseEntity<Object> handleIOException(IOException ex) {
+        log.error("handleIOException", ex);
+        return handleExceptionInternal(ErrorCode.IO_ERROR);
+    }
+
+    /**
+     * com.fasterxml.jackson.core 내에 Exception 발생하는 경우
+     *
+     * @param ex JsonProcessingException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(JsonProcessingException.class)
+    protected ResponseEntity<Object> handleJsonProcessingException(JsonProcessingException ex) {
+        log.error("handleJsonProcessingException", ex);
+        return handleExceptionInternal(ErrorCode.REQUEST_BODY_MISSING_ERROR);
+    }
+
+    /**
+     * [Exception] 잘못된 주소로 요청 한 경우
+     *
+     * @param e NoHandlerFoundException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<Object> handleNoHandlerFoundExceptionException(NoHandlerFoundException e) {
+        log.error("handleNoHandlerFoundExceptionException", e);
+        return handleExceptionInternal(ErrorCode.NOT_FOUND_ERROR);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(BaseResponse<?> response) {
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCommonStatus) {
+        BaseResponse<?> baseResponse = BaseResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return new ResponseEntity<>(baseResponse, HttpStatus.OK);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/handler/MyExceptionHandler.java
+++ b/server/src/main/java/com/onetool/server/global/handler/MyExceptionHandler.java
@@ -1,0 +1,10 @@
+package com.example.exception.handler;
+
+import com.example.exception.common.BaseException;
+import com.example.exception.common.codes.BaseCode;
+
+public class MyExceptionHandler extends BaseException {
+    public MyExceptionHandler (BaseCode code){
+        super(code);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

global exception 및 api 응답 형식 통일

모든 http 요청에 대해 응답을 200 ok로 처리하고 응답 메세지 안에 성공 혹은 실패 관련 스토리를 적는다.

{
    "isSuccess": true 또는 false,
    "code": "에러 코드 혹은 성공 코드",
    "message": "에러 메세지 혹은 성공 메세지"
    "result" : "success 시 반환해야 할 문자열이나 데이터들을 여기다가 넣으면 됨"
}
중요한 것은 success는 반드시 result에 값이 있어야 함.(성공 메세지랑 성공 시 result 안에 넣은 메세지는 다른 것 )

ex.

{
    "isSuccess": true,
    "code": "SUCCESS-0000",
    "message": "요청에 성공하였습니다.",
    "result": "로그인에 성공했습니다."
}

{
    "isSuccess": false,
    "code": "BINDING-0000",
    "message": "이메일을 형식에 맞게 다시 입력해주세요."
}


사용 방법은 global/exception/howToUse에 있는 컨트롤러와 서비스를 참고해주세요

## 🔧 앞으로의 과제

서비스에서 생길 수 있는 예외들을 생각하고 그런 오류들은 ErrorCode에 만들어 주세요
