### PR TITLE
feat: 구글 SSO 로그인

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.3.2'
+
+	testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }
 
 tasks.named('test') {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
+
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.3.2'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
+++ b/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
@@ -35,7 +35,6 @@ public class JwtUtil implements AuthorizationProvider {
     @Override
     public String create(MemberAuthContext context) {
         Claims claims = Jwts.claims();
-        claims.put("memberId", context.getId());
         claims.put("email", context.getEmail());
         claims.put("role", context.getRole());
 

--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -5,6 +5,9 @@ import com.onetool.server.global.auth.CustomAccessDeniedHandler;
 import com.onetool.server.global.auth.CustomAuthenticationEntryPoint;
 import com.onetool.server.global.auth.filter.JwtAuthFilter;
 import com.onetool.server.global.auth.jwt.JwtUtil;
+import com.onetool.server.global.oauth2.handler.OAuth2LoginFailureHandler;
+import com.onetool.server.global.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.onetool.server.global.oauth2.service.CustomOAuth2UserService;
 import com.onetool.server.member.service.CustomUserDetailsService;
 import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -27,9 +30,12 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     private static final String[] AUTH_WHITELIST = {
-        "/users/login/**"
+        "/users/login/**", "/login/**"
     };
 
     @Bean
@@ -50,7 +56,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .anyRequest().authenticated())
-                .oauth2Login(Customizer.withDefaults());
+                .oauth2Login(auth -> {
+                    auth.successHandler(oAuth2LoginSuccessHandler)
+                            .failureHandler(oAuth2LoginFailureHandler)
+                            .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOAuth2UserService));
+                });
 
         return http.build();
     }

--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     private static final String[] AUTH_WHITELIST = {
-        "/users/login/**", "/login/**"
+        "/users/login/**", "/login/**",
+            "/users/signup/**"
     };
 
     @Bean

--- a/server/src/main/java/com/onetool/server/global/oauth2/CustomOAuth2User.java
+++ b/server/src/main/java/com/onetool/server/global/oauth2/CustomOAuth2User.java
@@ -1,0 +1,26 @@
+package com.onetool.server.global.oauth2;
+
+import com.onetool.server.member.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private String email;
+    private UserRole role;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes, String nameAttributeKey,
+                            String email, UserRole role) {
+        super(authorities, attributes, nameAttributeKey);
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/oauth2/OAuthAttributes.java
+++ b/server/src/main/java/com/onetool/server/global/oauth2/OAuthAttributes.java
@@ -1,0 +1,49 @@
+package com.onetool.server.global.oauth2;
+
+import com.onetool.server.global.oauth2.userinfo.OAuth2UserInfo;
+import com.onetool.server.global.oauth2.userinfo.GoogleOAuth2UserInfo;
+import com.onetool.server.member.Member;
+import com.onetool.server.member.SocialType;
+import com.onetool.server.member.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Getter
+public class OAuthAttributes {
+
+    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private OAuth2UserInfo oAuth2UserInfo;
+
+    @Builder
+    public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oAuth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oAuth2UserInfo = oAuth2UserInfo;
+    }
+
+    public static OAuthAttributes of(SocialType socialType,
+                                     String userNameAttributeName, Map<String, Object> attributes)  {
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oAuth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public Member toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
+        return Member.builder()
+                .socialType(socialType)
+                .socialId(oauth2UserInfo.getId())
+                .email(UUID.randomUUID() + "@socialUser.com")
+                .name(oauth2UserInfo.getName())
+                .role(UserRole.ROLE_GUEST)
+                .build();
+    }
+}
+
+

--- a/server/src/main/java/com/onetool/server/global/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/server/src/main/java/com/onetool/server/global/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,22 @@
+package com.onetool.server.global.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/server/src/main/java/com/onetool/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,59 @@
+package com.onetool.server.global.oauth2.handler;
+
+import com.onetool.server.global.auth.MemberAuthContext;
+import com.onetool.server.global.auth.jwt.JwtUtil;
+import com.onetool.server.global.oauth2.CustomOAuth2User;
+import com.onetool.server.member.MemberRepository;
+import com.onetool.server.member.UserRole;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login 성공");
+        try {
+            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+            if(oAuth2User.getRole() == UserRole.ROLE_GUEST) {
+                MemberAuthContext memberAuthContext = MemberAuthContext.builder()
+                        .email(oAuth2User.getEmail())
+                        .role(oAuth2User.getRole().name())
+                        .build();
+                String accessToken = jwtUtil.create(memberAuthContext);
+                response.addHeader("Authorization", "Bearer " + accessToken);
+                response.sendRedirect("oauth2/sign-up");
+                response.setStatus(HttpServletResponse.SC_OK);
+            } else {
+                loginSuccess(response, oAuth2User);
+            }
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws  IOException {
+        MemberAuthContext memberAuthContext = MemberAuthContext.builder()
+                .email(oAuth2User.getEmail())
+                .role(oAuth2User.getRole().name())
+                .build();
+        String accessToken = jwtUtil.create(memberAuthContext);
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/oauth2/service/CustomOAuth2UserService.java
+++ b/server/src/main/java/com/onetool/server/global/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,75 @@
+package com.onetool.server.global.oauth2.service;
+
+import com.onetool.server.global.oauth2.CustomOAuth2User;
+import com.onetool.server.global.oauth2.OAuthAttributes;
+import com.onetool.server.member.Member;
+import com.onetool.server.member.MemberRepository;
+import com.onetool.server.member.SocialType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+
+    private static final String GOOGLE = "google";
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        SocialType socialType = getSocialType(registrationId);
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+
+        Member createdMember = getMember(extractAttributes, socialType);
+
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().name())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdMember.getEmail(),
+                createdMember.getRole()
+        );
+    }
+
+    private SocialType getSocialType(String registrationId) {
+        return SocialType.GOOGLE;
+    }
+
+    private Member getMember(OAuthAttributes attributes, SocialType socialType) {
+        Member findMember = memberRepository.findBySocialTypeAndSocialId(
+                socialType, attributes.getOAuth2UserInfo().getId()).orElse(null);
+
+        if(findMember == null) {
+            return saveMember(attributes, socialType);
+        }
+        return findMember;
+    }
+
+    private Member saveMember(OAuthAttributes attributes, SocialType socialType) {
+        Member createdMember = attributes.toEntity(socialType, attributes.getOAuth2UserInfo());
+        log.info("saveMember() - email 길이 : " + createdMember.getEmail().length() );
+        return memberRepository.save(createdMember);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/server/src/main/java/com/onetool/server/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package com.onetool.server.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/oauth2/userinfo/OAuth2UserInfo.java
+++ b/server/src/main/java/com/onetool/server/global/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,16 @@
+package com.onetool.server.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId(); //소셜 식별 값 : 구글 - "sub", 카카오 - "id", 네이버 - "id"
+
+    public abstract String getName();
+}

--- a/server/src/main/java/com/onetool/server/member/DateTimeFormat.java
+++ b/server/src/main/java/com/onetool/server/member/DateTimeFormat.java
@@ -1,0 +1,8 @@
+package com.onetool.server.member;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeFormat {
+    public static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+}

--- a/server/src/main/java/com/onetool/server/member/Member.java
+++ b/server/src/main/java/com/onetool/server/member/Member.java
@@ -25,7 +25,7 @@ public class Member extends BaseEntity {
 
     private String password;
 
-    @NotNull @Size(min = 1, max = 50, message = "이메일은 1 ~ 50자 이여야 합니다.") @Email
+    @NotNull @Size(min = 1, max = 100, message = "이메일은 1 ~ 100자 이여야 합니다.") @Email
     private String email;
 
     @NotNull(message = "이름은 null 일 수 없습니다.") @Size(min = 1, max = 10, message = "이름은 1 ~ 10자 이여야 합니다.")
@@ -34,7 +34,7 @@ public class Member extends BaseEntity {
     @Column(name = "birth_daye") @Past
     private LocalDate birthDate;
 
-    @Column(name = "phone_num") @NotNull @Size(min = 10, max = 11)
+    @Column(name = "phone_num") @Size(min = 10, max = 11)
     private String phoneNum;
 
     @Column(name = "user_role")
@@ -50,8 +50,13 @@ public class Member extends BaseEntity {
     @Column(name = "service_accept")
     private boolean serviceAccept;
 
-    @Column(name = "platform_type") @NotNull
+    @Column(name = "platform_type")
     private String platformType;
+
+    @Column(name = "social_type")
+    private SocialType socialType;
+
+    private String socialId;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<QnaBoard> qnaBoards = new ArrayList<>();
@@ -60,7 +65,8 @@ public class Member extends BaseEntity {
     private Cart cart;
 
     @Builder
-    public Member(String password, String email, String name, LocalDate birthDate, String phoneNum, UserRole role, String field, boolean isNative, boolean serviceAccept, String platformType, List<QnaBoard> qnaBoards, Cart cart) {
+    public Member(Long id, String password, String email, String name, LocalDate birthDate, String phoneNum, UserRole role, String field, boolean isNative, boolean serviceAccept, String platformType, SocialType socialType, String socialId, List<QnaBoard> qnaBoards, Cart cart) {
+        this.id = id;
         this.password = password;
         this.email = email;
         this.name = name;
@@ -71,6 +77,8 @@ public class Member extends BaseEntity {
         this.isNative = isNative;
         this.serviceAccept = serviceAccept;
         this.platformType = platformType;
+        this.socialType = socialType;
+        this.socialId = socialId;
         this.qnaBoards = qnaBoards;
         this.cart = cart;
     }

--- a/server/src/main/java/com/onetool/server/member/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/MemberController.java
@@ -1,11 +1,17 @@
 package com.onetool.server.member;
 
 import com.onetool.server.member.dto.LoginRequest;
+import com.onetool.server.member.dto.MemberCreateRequest;
+import com.onetool.server.member.dto.MemberCreateResponse;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.net.URI;
 
 @Controller
 public class MemberController {
@@ -21,6 +27,16 @@ public class MemberController {
             @Valid @RequestBody LoginRequest request
     ) {
         String token = memberService.login(request);
-        return ResponseEntity.ok(token);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+
+        return new ResponseEntity<>("유저가 로그인되었습니다.",headers, HttpStatus.OK);
     }
+
+    @PostMapping("/users/signup")
+    public ResponseEntity<MemberCreateResponse> createMember(@RequestBody MemberCreateRequest request) {
+        MemberCreateResponse response = memberService.createMember(request);
+        return ResponseEntity.created(URI.create("/users/" + response.id())).body(response);
+    }
+
 }

--- a/server/src/main/java/com/onetool/server/member/MemberRepository.java
+++ b/server/src/main/java/com/onetool/server/member/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query(value = "SELECT count(*) FROM Member")
     Long countAllMember();
+
+    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String id);
 }

--- a/server/src/main/java/com/onetool/server/member/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/MemberService.java
@@ -4,6 +4,8 @@ import com.onetool.server.global.auth.MemberAuthContext;
 import com.onetool.server.global.auth.jwt.JwtUtil;
 import com.onetool.server.global.exception.MemberNotFoundException;
 import com.onetool.server.member.dto.LoginRequest;
+import com.onetool.server.member.dto.MemberCreateRequest;
+import com.onetool.server.member.dto.MemberCreateResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -20,6 +22,11 @@ public class MemberService {
     private final JwtUtil jwtUtil;
     private final MemberRepository memberRepository;
     private final PasswordEncoder encoder;
+
+    public MemberCreateResponse createMember(MemberCreateRequest request) {
+        Member member = memberRepository.save(request.toEntity());
+        return MemberCreateResponse.of(member);
+    }
 
     public String login(LoginRequest request) {
         String email = request.getEmail();

--- a/server/src/main/java/com/onetool/server/member/SSOTestController.java
+++ b/server/src/main/java/com/onetool/server/member/SSOTestController.java
@@ -1,0 +1,13 @@
+package com.onetool.server.member;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class SSOTestController {
+
+    @GetMapping("/login/sso")
+    public String gotoSsoLoginPage() {
+        return "login";
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/SocialType.java
+++ b/server/src/main/java/com/onetool/server/member/SocialType.java
@@ -1,0 +1,5 @@
+package com.onetool.server.member;
+
+public enum SocialType {
+    NAVER, KAKAO, GOOGLE
+}

--- a/server/src/main/java/com/onetool/server/member/UserRole.java
+++ b/server/src/main/java/com/onetool/server/member/UserRole.java
@@ -1,5 +1,5 @@
 package com.onetool.server.member;
 
 public enum UserRole {
-    ROLE_USER, ROLE_ADMIN
+    ROLE_USER, ROLE_ADMIN, ROLE_GUEST
 }

--- a/server/src/main/java/com/onetool/server/member/dto/MemberCreateRequest.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberCreateRequest.java
@@ -1,0 +1,42 @@
+package com.onetool.server.member.dto;
+
+import com.onetool.server.member.DateTimeFormat;
+import com.onetool.server.member.Member;
+import com.onetool.server.member.UserRole;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+public record MemberCreateRequest(
+        String email,
+        String password,
+        String name,
+        String birthDate,
+        String development_field,
+        String phoneNum,
+        boolean isNative
+) {
+    @Builder
+    public MemberCreateRequest(String email, String password, String name, String birthDate, String development_field, String phoneNum, boolean isNative) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.birthDate = birthDate;
+        this.development_field = development_field;
+        this.phoneNum = phoneNum;
+        this.isNative = isNative;
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .email(email)
+                .role(UserRole.ROLE_USER)
+                .password(password)
+                .birthDate(LocalDate.parse(birthDate, DateTimeFormat.dateFormat))
+                .name(name)
+                .isNative(isNative)
+                .field(development_field)
+                .phoneNum(phoneNum)
+                .build();
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/dto/MemberCreateResponse.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberCreateResponse.java
@@ -1,0 +1,26 @@
+package com.onetool.server.member.dto;
+
+import com.onetool.server.member.Member;
+import lombok.Builder;
+
+public record MemberCreateResponse(
+        Long id,
+        String email,
+        String name
+) {
+
+    @Builder
+    public MemberCreateResponse(Long id, String email, String name) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+    }
+
+    public static MemberCreateResponse of(Member member) {
+        return MemberCreateResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .build();
+    }
+}

--- a/server/src/main/resources/templates/login.html
+++ b/server/src/main/resources/templates/login.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <a href="/oauth2/authorization/google">Google Login</a><br>
+</body>
+</html>

--- a/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
+++ b/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
@@ -1,0 +1,53 @@
+package com.onetool.server.member;
+
+import groovy.util.logging.Slf4j;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class MemberServiceTest {
+
+    @Test
+    void create_member() {
+        // given
+        final Map<String, Object> params = Map.of(
+                "email", "admin@example.com",
+                "password", "1234",
+                "name", "홍길동",
+                "birthDate", "2001-03-26",
+                "development_field", "백엔드",
+                "phoneNum", "010-0000-0000",
+                "isNative", true
+        );
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/users/signup")
+                .then().log().all()
+                .extract();
+
+        // then
+        final JsonPath result = response.jsonPath();
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(result.getString("email")).isEqualTo("admin@example.com"),
+                () -> assertThat(result.getString("name")).isEqualTo("홍길동")
+        );
+    }
+}


### PR DESCRIPTION
## feat: 구글 로그인 구현
[ SSO 관련 파일 설명 ]

OAuth2LoginFailureHandler : SSO 로그인 실패 시 핸들러

OAuth2LoginSuccessHandler : SSO 로그인 성공 시 핸들러

CustomOAuth2UserService : Resource Server에서 받아온 정보를 DB에 저장, OAuth2User에 로그인 정보 저장

CustomOAuth2User : DefaultOAuth2User를 상속받아 SSO 로그인된 유저 정보를 저장

OAuthAttributes : 각 SSO에서 받아오는 데이터가 다르므로,SSO 별로 받는 데이터를 분기 처리하는 DTO 클래스

SocialType : SSO enum 클래스

SSOTestController : SSO 테스트를 위한 컨틀로러로 login.html로 이동

login.html : SSO 로그인을 확인하기 위한 트리거 제공하는 동적 페이지

<br/>

## 🔧 앞으로의 과제

- 일반 회원가입 구현

- 일반 로그인과의 충돌 테스트

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>