### PR TITLE
fix: PrincipalDetail에 로그인 유저가 저장되지 않는 버그 수정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	//developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -38,9 +38,9 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-web:6.3.1'
 	implementation 'org.springframework.security:spring-security-config:6.3.1'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
-	implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-gson:0.12.6'
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.3.2'

--- a/server/src/main/java/com/onetool/server/global/auth/CustomAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/onetool/server/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,13 +1,13 @@
 package com.onetool.server.global.auth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.ErrorResponse;
 
 import java.io.IOException;
 
@@ -16,10 +16,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        String accept = request.getHeader("Accept");
-
-        if ("application/json".equals(accept)) {
-            response.setStatus(401);
-        }
+        response.setStatus(HttpStatus.SC_BAD_REQUEST);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("접근 권한이 없습니다.");
     }
 }

--- a/server/src/main/java/com/onetool/server/global/auth/MemberAuthContext.java
+++ b/server/src/main/java/com/onetool/server/global/auth/MemberAuthContext.java
@@ -8,6 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @Setter
+@ToString
 @Builder
 public class MemberAuthContext {
     private Long id;

--- a/server/src/main/java/com/onetool/server/global/auth/filter/JwtAuthFilter.java
+++ b/server/src/main/java/com/onetool/server/global/auth/filter/JwtAuthFilter.java
@@ -1,6 +1,7 @@
 package com.onetool.server.global.auth.filter;
 
 import com.onetool.server.global.auth.jwt.JwtUtil;
+import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.MemberNotFoundException;
 import com.onetool.server.global.auth.login.service.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
@@ -8,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,6 +17,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
 
@@ -28,23 +31,24 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         //JWT가 헤더에 있는 경우
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             String token = authorizationHeader.substring(7);
+            log.info("토큰: " + token);
             //JWT 유효성 검증
             if (jwtUtil.validateToken(token)) {
+                log.info("validation 통과");
                 Long userId = jwtUtil.getUserId(token);
 
-                //유저와 토큰 일치 시 userDetails 생성
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(userId.toString());
+                //유저와 토큰 일치 시 principalDetails 생성
+                PrincipalDetails principalDetails = customUserDetailsService.loadUserByUsername(userId.toString());
 
-                if (userDetails != null) {
+                if (principalDetails != null) {
                     //UserDetsils, Password, Role -> 접근권한 인증 Token 생성
                     UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                            new UsernamePasswordAuthenticationToken(principalDetails, token, principalDetails.getAuthorities());
 
                     //현재 Request의 Security Context에 접근권한 설정
+                    log.info("필터 설정됨: ");
                     SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
                 }
-            } else {
-                throw new MemberNotFoundException();
             }
         }
 

--- a/server/src/main/java/com/onetool/server/global/auth/login/service/CustomUserDetailsService.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/service/CustomUserDetailsService.java
@@ -18,7 +18,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+    public PrincipalDetails loadUserByUsername(String id) throws UsernameNotFoundException {
         Member member = memberRepository.findById(Long.parseLong(id))
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저가 없습니다."));
 

--- a/server/src/main/java/com/onetool/server/member/controller/SSOTestController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/SSOTestController.java
@@ -1,13 +1,30 @@
 package com.onetool.server.member.controller;
 
+import com.onetool.server.global.auth.MemberAuthContext;
+import com.onetool.server.global.auth.login.PrincipalDetails;
+import com.onetool.server.member.domain.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.security.Principal;
+
+@Slf4j
 @Controller
 public class SSOTestController {
 
     @GetMapping("/login/sso")
     public String gotoSsoLoginPage() {
         return "login";
+    }
+
+    @GetMapping("/principal")
+    public ResponseEntity getPrincipal(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        log.info(principalDetails.toString());
+        return ResponseEntity.ok(principalDetails);
     }
 }

--- a/server/src/main/java/com/onetool/server/member/dto/MemberCreateRequest.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberCreateRequest.java
@@ -27,11 +27,11 @@ public record MemberCreateRequest(
         this.isNative = isNative;
     }
 
-    public Member toEntity() {
+    public Member toEntity(String encoded) {
         return Member.builder()
                 .email(email)
                 .role(UserRole.ROLE_USER)
-                .password(password)
+                .password(encoded)
                 .birthDate(LocalDate.parse(birthDate, DateTimeFormat.dateFormat))
                 .name(name)
                 .isNative(isNative)

--- a/server/src/main/java/com/onetool/server/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/service/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
     private final PasswordEncoder encoder;
 
     public MemberCreateResponse createMember(MemberCreateRequest request) {
-        Member member = memberRepository.save(request.toEntity());
+        Member member = memberRepository.save(request.toEntity(encoder.encode(request.password())));
         log.info("회원가입됨:" + member.getEmail());
         return MemberCreateResponse.of(member);
     }


### PR DESCRIPTION
## 🔎 작업 내용

- GSON의 버그로 인해 Jwt의 Claim에 Long 값을 넣으면, Double로 변환되어 저장됨.
- 이를 명시적 형변환을 통해 해결


<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>