### PR TITLE
test: 모든 카테고리의 도면 검색 테스트 / fix: SSO 로그인 시, PlatformType을 SSO로 지정

### DIFF
--- a/server/src/main/java/com/onetool/server/global/auth/login/OAuthAttributes.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/OAuthAttributes.java
@@ -42,6 +42,7 @@ public class OAuthAttributes {
                 .email(UUID.randomUUID() + "@socialUser.com")
                 .name(oauth2UserInfo.getName())
                 .role(UserRole.ROLE_GUEST)
+                .platformType("SSO")
                 .build();
     }
 }

--- a/server/src/test/java/com/onetool/server/category/CategoryServiceTest.java
+++ b/server/src/test/java/com/onetool/server/category/CategoryServiceTest.java
@@ -72,11 +72,4 @@ public class CategoryServiceTest {
         assertThat(response.getTotalElements()).isEqualTo(1);
     }
 
-    @DisplayName("모든 category의 blueprint를 검색한다.")
-    @Test
-    void search_all_category() {
-        Pageable pageable = PageRequest.of(0, 5);
-        Page<SearchResponse> response = blueprintService.findAll(pageable);
-        assertThat(response.getTotalElements()).isEqualTo(6L);
-    }
 }

--- a/server/src/test/java/com/onetool/server/category/CategoryServiceTest.java
+++ b/server/src/test/java/com/onetool/server/category/CategoryServiceTest.java
@@ -72,4 +72,11 @@ public class CategoryServiceTest {
         assertThat(response.getTotalElements()).isEqualTo(1);
     }
 
+    @DisplayName("모든 category의 blueprint를 검색한다.")
+    @Test
+    void search_all_category() {
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<SearchResponse> response = blueprintService.findAll(pageable);
+        assertThat(response.getTotalElements()).isEqualTo(6L);
+    }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- CategoryServiceTest에 테스트 통과
- SSO 로그인 시, PlatformType을 SSO로 지정
    - Member의 `PlatformType` : **SSO 회원과 일반회원 구분**
    - Member의 'SocialType' : **SSO의 플랫폼 구분**
<br/>

## 🔧 앞으로의 과제



  <br/>

## ➕ 이슈 링크



<br/>