### PR TITLE
feat: 이메일 인증 및 Redis 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.apache.httpcomponents:httpcore:4.3.2'
 	compileOnly 'org.projectlombok:lombok'
 	//developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -46,6 +47,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.3.2'
 
 	testImplementation 'io.rest-assured:rest-assured:5.5.0'
+
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
+	implementation 'javax.mail:javax.mail-api:1.6.2'
+	//implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
+	implementation 'com.sun.mail:smtp:2.0.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/onetool/server/global/auth/CustomAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/onetool/server/global/auth/CustomAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.onetool.server.global.auth;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -11,11 +12,13 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.info(request.getHeader("Authorization"));
         response.setStatus(HttpStatus.SC_BAD_REQUEST);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/server/src/main/java/com/onetool/server/global/config/EmailConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/EmailConfig.java
@@ -1,0 +1,72 @@
+package com.onetool.server.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Slf4j
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        log.info("host: "+host);
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setProtocol("smtp");
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/config/RedisConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.onetool.server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    // RedisProperties로 yaml에 저장한 host, post를 연결
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    // serializer 설정으로 redis-cli를 통해 직접 데이터를 조회할 수 있도록 설정
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/BusinessLogicException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/BusinessLogicException.java
@@ -1,0 +1,6 @@
+package com.onetool.server.global.exception;
+
+public class BusinessLogicException extends RuntimeException {
+    public BusinessLogicException() {
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/DuplicateMemberException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/DuplicateMemberException.java
@@ -1,0 +1,6 @@
+package com.onetool.server.global.exception;
+
+public class DuplicateMemberException extends RuntimeException{
+    public DuplicateMemberException() {
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/handler/MemberControllerAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/MemberControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.onetool.server.global.handler;
 
+import com.onetool.server.global.exception.DuplicateMemberException;
 import com.onetool.server.global.exception.MemberNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -11,5 +12,10 @@ public class MemberControllerAdvice {
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity handleNotFoundMemberException(MemberNotFoundException e) {
         return ResponseEntity.badRequest().body("유저를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(DuplicateMemberException.class)
+    public ResponseEntity handleDuplicateMemberException(DuplicateMemberException e) {
+        return ResponseEntity.badRequest().body("이메일이 중복됩니다.");
     }
 }

--- a/server/src/main/java/com/onetool/server/global/redis/RedisService.java
+++ b/server/src/main/java/com/onetool/server/global/redis/RedisService.java
@@ -1,0 +1,67 @@
+package com.onetool.server.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expireValues(String key, int timeout) {
+        redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public void setHashOps(String key, Map<String, String> data) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    @Transactional(readOnly = true)
+    public String getHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        return Boolean.TRUE.equals(values.hasKey(key, hashKey)) ? (String) redisTemplate.opsForHash().get(key, hashKey) : "";
+    }
+
+    public void deleteHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}

--- a/server/src/main/java/com/onetool/server/mail/MailService.java
+++ b/server/src/main/java/com/onetool/server/mail/MailService.java
@@ -1,0 +1,43 @@
+package com.onetool.server.mail;
+
+import com.onetool.server.global.exception.BusinessLogicException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender emailSender;
+
+    public void sendEmail(String toEmail,
+                          String title,
+                          String text) {
+        SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
+        //try {
+            emailSender.send(emailForm);
+//        } catch (RuntimeException e) {
+//            log.error("MailService.sendEmail exception occur toEmail: {}, " +
+//                    "title: {}, text: {}", toEmail, title, text);
+//            throw new BusinessLogicException();
+//        }
+    }
+
+    // 발신할 이메일 데이터 세팅
+    private SimpleMailMessage createEmailForm(String toEmail,
+                                              String title,
+                                              String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+
+        return message;
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -9,12 +9,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
 @Controller
+@RequestMapping("/users")
 public class MemberController {
 
     private final MemberService memberService;
@@ -23,7 +23,7 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    @PostMapping("/users/login")
+    @PostMapping("/login")
     public ResponseEntity<String> login(
             @Valid @RequestBody LoginRequest request
     ) {
@@ -34,10 +34,24 @@ public class MemberController {
         return new ResponseEntity<>("유저가 로그인되었습니다.",headers, HttpStatus.OK);
     }
 
-    @PostMapping("/users/signup")
+    @PostMapping("/signup")
     public ResponseEntity<MemberCreateResponse> createMember(@RequestBody MemberCreateRequest request) {
         MemberCreateResponse response = memberService.createMember(request);
         return ResponseEntity.created(URI.create("/users/" + response.id())).body(response);
     }
 
+    @PostMapping("/emails/verification-requests")
+    public ResponseEntity sendMessage(@RequestParam("email") @Valid String email) {
+        memberService.sendCodeToEmail(email);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/emails/verifications")
+    public ResponseEntity verificationEmail(@RequestParam("email") @Valid String email,
+                                            @RequestParam("code") String authCode) {
+        boolean response = memberService.verifiedCode(email, authCode);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 }

--- a/server/src/test/java/com/onetool/server/redis/RedisCrudTest.java
+++ b/server/src/test/java/com/onetool/server/redis/RedisCrudTest.java
@@ -1,0 +1,85 @@
+package com.onetool.server.redis;
+
+import com.onetool.server.global.redis.RedisService;
+import groovy.util.logging.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Slf4j
+@SpringBootTest
+public class RedisCrudTest {
+    final String KEY = "key";
+    final String VALUE = "value";
+    final Duration DURATION = Duration.ofMillis(5000);
+    @Autowired
+    private RedisService redisService;
+
+    @BeforeEach
+    void shutDown() {
+        redisService.setValues(KEY, VALUE, DURATION);
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisService.deleteValues(KEY);
+    }
+
+    @Test
+    @DisplayName("Redis에 데이터를 저장하면 정상적으로 조회된다.")
+    void saveAndFindTest() throws Exception {
+        // when
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(VALUE).isEqualTo(findValue);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터를 수정할 수 있다.")
+    void updateTest() throws Exception {
+        // given
+        String updateValue = "updateValue";
+        redisService.setValues(KEY, updateValue, DURATION);
+
+        // when
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(updateValue).isEqualTo(findValue);
+        assertThat(VALUE).isNotEqualTo(findValue);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터를 삭제할 수 있다.")
+    void deleteTest() throws Exception {
+        // when
+        redisService.deleteValues(KEY);
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(findValue).isEqualTo("false");
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터는 만료시간이 지나면 삭제된다.")
+    void expiredTest() throws Exception {
+        // when
+        String findValue = redisService.getValues(KEY);
+        await().pollDelay(Duration.ofMillis(6000)).untilAsserted(
+                () -> {
+                    String expiredValue = redisService.getValues(KEY);
+                    assertThat(expiredValue).isNotEqualTo(findValue);
+                    assertThat(expiredValue).isEqualTo("false");
+                }
+        );
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
요청된 메일주소로 랜덤한 인증번호를 생성합니다. 인증번호는 `Redis`에 저장됩니다.
이후 사용자가 입력한 인증번호와 이메일주소를 바탕으로 Redis에 저장된 인증번호를 확인합니다.
만약 인증번호가 올바르면 `200/true`를 반환하고, 그렇지 않다면 `400/false`를 반환합니다.

### 클래스 설명
- `EmailConfig` : 이메일을 보낼 JavaMailSender 구현체 정의
- `MemberController`: 코드 발송 엔드포인트, 코드 검증 엔드포인트 각각 구현
- `RedisConfig`: Redis 설정
- `MailService`: 메일 발송 및 코드 검증 비즈니스 로직

<br/>

## 🔧 앞으로의 과제

- submodule의 redis 포트번호를 6380 -> 6379로 변경

  <br/>

## ➕ 이슈 링크


<br/>