### PR TITLE
feat: 비밀번호 찾기 이메일 발송 구현 (임시)

### DIFF
--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -34,8 +34,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     private static final String[] AUTH_WHITELIST = {
-        "/users/login/**", "/login/**",
-            "/users/signup/**", "/blueprint/**"
+        "/users/**", "/login/**", "/blueprint/**"
     };
 
     @Bean

--- a/server/src/main/java/com/onetool/server/mail/MailService.java
+++ b/server/src/main/java/com/onetool/server/mail/MailService.java
@@ -20,13 +20,13 @@ public class MailService {
                           String title,
                           String text) {
         SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
-        //try {
+        try {
             emailSender.send(emailForm);
-//        } catch (RuntimeException e) {
-//            log.error("MailService.sendEmail exception occur toEmail: {}, " +
-//                    "title: {}, text: {}", toEmail, title, text);
-//            throw new BusinessLogicException();
-//        }
+        } catch (RuntimeException e) {
+            log.error("MailService.sendEmail exception occur toEmail: {}, " +
+                    "title: {}, text: {}", toEmail, title, text);
+            throw new BusinessLogicException();
+        }
     }
 
     // 발신할 이메일 데이터 세팅

--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -1,9 +1,9 @@
 package com.onetool.server.member.controller;
 
+import com.onetool.server.member.domain.Member;
+import com.onetool.server.member.dto.*;
 import com.onetool.server.member.service.MemberService;
-import com.onetool.server.member.dto.LoginRequest;
-import com.onetool.server.member.dto.MemberCreateRequest;
-import com.onetool.server.member.dto.MemberCreateResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -53,5 +53,15 @@ public class MemberController {
         boolean response = memberService.verifiedCode(email, authCode);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/password")
+    public ResponseEntity findPwdCheck(@RequestBody MemberFindPwdRequest request) {
+        boolean successFlag = memberService.findLostPwd(request);
+        if(successFlag) {
+            return ResponseEntity.ok("이메일을 발송했습니다.");
+        } else {
+            return ResponseEntity.badRequest().body("이메일 발송 과정에서 오류가 발생했습니다.");
+        }
     }
 }

--- a/server/src/main/java/com/onetool/server/member/dto/MemberFindPwdRequest.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberFindPwdRequest.java
@@ -1,0 +1,19 @@
+package com.onetool.server.member.dto;
+
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Data
+@Setter
+@Getter
+@NoArgsConstructor
+public class MemberFindPwdRequest {
+
+    private String email;
+
+    @Builder
+    public MemberFindPwdRequest(String email) {
+        this.email = email;
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/service/MemberService.java
@@ -7,11 +7,9 @@ import com.onetool.server.global.exception.DuplicateMemberException;
 import com.onetool.server.global.exception.MemberNotFoundException;
 import com.onetool.server.global.redis.RedisService;
 import com.onetool.server.mail.MailService;
+import com.onetool.server.member.dto.*;
 import com.onetool.server.member.repository.MemberRepository;
 import com.onetool.server.member.domain.Member;
-import com.onetool.server.member.dto.LoginRequest;
-import com.onetool.server.member.dto.MemberCreateRequest;
-import com.onetool.server.member.dto.MemberCreateResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +17,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.swing.text.html.Option;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
@@ -109,5 +108,17 @@ public class MemberService {
         String redisAuthCode = redisService.getValues(AUTH_CODE_PREFIX + email);
 
         return redisService.checkExistsValue(redisAuthCode) && redisAuthCode.equals(authCode);
+    }
+
+    public boolean findLostPwd(MemberFindPwdRequest request) {
+        String email = request.getEmail();
+        Member member =  memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+        mailService.sendEmail(
+                member.getEmail(),
+                "원툴 비밀번호 찾기",
+                member.getPassword()
+        );
+        return true;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 비밀번호 찾기 시, 가입 시 입력한 이메일로 비밀번호를 발송
- 현재 암호화된 비밀번호를 발송하도록 구현됨.
- 추후, 비밀번호 변경 기능 구현 시 임시 비밀번호 발급


<br/>

## 🔧 앞으로의 과제

- 비밀번호 변경 구현
- 랜덤 비밀번호 생성 및 발송 로직 수정

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>