### PR TITLE
fix: MemberUpdateRequest의 필드에 Valid 제거

### DIFF
--- a/server/src/main/java/com/onetool/server/member/dto/MemberFindEmailRequest.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberFindEmailRequest.java
@@ -1,0 +1,7 @@
+package com.onetool.server.member.dto;
+
+public record MemberFindEmailRequest(
+        String name,
+        String birth_date
+) {
+}

--- a/server/src/main/java/com/onetool/server/member/dto/MemberSimpleInfoDto.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberSimpleInfoDto.java
@@ -1,0 +1,17 @@
+package com.onetool.server.member.dto;
+
+import com.onetool.server.member.domain.Member;
+
+public record MemberSimpleInfoDto(
+        String name,
+        String email,
+        String phoneNum
+) {
+    public static MemberSimpleInfoDto makeMemberSimpInfoDto(Member member){
+        return new MemberSimpleInfoDto(
+                member.getName(),
+                member.getEmail(),
+                member.getPhoneNum()
+        );
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/dto/MemberUpdateRequest.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberUpdateRequest.java
@@ -1,20 +1,14 @@
 package com.onetool.server.member.dto;
 
 import lombok.Builder;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class MemberUpdateRequest {
-    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
-
-    @NotBlank(message = "이름은 필수입니다.")
     private String name;
-
     private String phoneNum;
     private String developmentField;
-
     private String currentPassword;
     private String newPassword;
 


### PR DESCRIPTION
## 🔎 작업 내용
- 업데이트의 경우, 변경된 값만 받으면 되기 때문에 https://github.com/NotNull 등의 Valid는 불필요하다 판단
- chore: 이메일찾기 DTO, 유저 간단 정보 DTO

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

<br/>