### PR TITLE
feat: 회원 정보 조회/refactor: 이름과 전화번호를 통한 이메일 찾기

### DIFF
--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -88,4 +88,19 @@ public class MemberController {
 
         return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
     }
+
+    @GetMapping
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long id = principalDetails.getContext().getId();
+
+        try {
+            MemberInfoResponse memberResponse = memberService.getMemberInfo(id);
+            return ResponseEntity.ok(memberResponse);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+    }
+
 }

--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -42,6 +42,12 @@ public class MemberController {
         return ResponseEntity.created(URI.create("/users/" + response.id())).body(response);
     }
 
+    @PostMapping("/email")
+    public  ResponseEntity findEmail(@RequestBody MemberFindEmailRequest request) {
+        String email = memberService.findEmail(request);
+        return ResponseEntity.ok(email);
+    }
+
     @PostMapping("/emails/verification-requests")
     public ResponseEntity sendMessage(@RequestParam("email") @Valid String email) {
         memberService.sendCodeToEmail(email);

--- a/server/src/main/java/com/onetool/server/member/domain/Member.java
+++ b/server/src/main/java/com/onetool/server/member/domain/Member.java
@@ -5,6 +5,7 @@ import com.onetool.server.global.entity.BaseEntity;
 import com.onetool.server.member.dto.MemberUpdateRequest;
 import com.onetool.server.member.enums.SocialType;
 import com.onetool.server.member.enums.UserRole;
+import com.onetool.server.order.Orders;
 import com.onetool.server.qna.QnaBoard;
 import com.onetool.server.qna.QnaReply;
 import jakarta.persistence.*;
@@ -74,6 +75,12 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Cart cart;
 
+    @OneToMany(mappedBy = "member")
+    @OrderBy("createdAt DESC")
+    private List<Orders> orders = new ArrayList<>();
+
+    @Column(name = "user_registered_at")
+    private LocalDate user_registered_at;
     @Builder
     public Member(Long id, String password, String email, String name, LocalDate birthDate, String phoneNum, UserRole role, String field, boolean isNative, boolean serviceAccept, String platformType, SocialType socialType, String socialId, List<QnaBoard> qnaBoards, List<QnaReply> qnaReplies, Cart cart) {
         this.id = id;
@@ -119,5 +126,9 @@ public class Member extends BaseEntity {
 
     public void initCart(Cart cart) {
         this.cart = cart;
+    }
+    @PrePersist
+    protected void onCreate() {
+        this.user_registered_at = LocalDate.now();
     }
 }

--- a/server/src/main/java/com/onetool/server/member/dto/MemberFindEmailRequest.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberFindEmailRequest.java
@@ -2,6 +2,6 @@ package com.onetool.server.member.dto;
 
 public record MemberFindEmailRequest(
         String name,
-        String birth_date
+        String phone_num
 ) {
 }

--- a/server/src/main/java/com/onetool/server/member/dto/MemberInfoResponse.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberInfoResponse.java
@@ -1,0 +1,56 @@
+package com.onetool.server.member.dto;
+
+import com.onetool.server.member.domain.Member;
+import com.onetool.server.order.dto.response.OrderResponse;
+import jakarta.validation.constraints.Past;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record MemberInfoResponse(
+        Long id,
+        String email,
+        String password,
+        String name,
+        @Past LocalDate birthDate,
+        String development_field,
+        String phoneNum,
+        boolean isNative,
+        boolean service_accept,
+        LocalDate user_registered_at,
+        List<OrderResponse.OrderCompleteResponseDto> orderCompleteResponseDtos
+) {
+    @Builder
+    public MemberInfoResponse(Long id, String email, String password, String name, @Past LocalDate birthDate, String development_field, String phoneNum, boolean isNative, boolean service_accept, LocalDate user_registered_at, List<OrderResponse.OrderCompleteResponseDto> orderCompleteResponseDtos) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.birthDate = birthDate;
+        this.development_field = development_field;
+        this.phoneNum = phoneNum;
+        this.isNative = isNative;
+        this.service_accept = service_accept;
+        this.user_registered_at = user_registered_at;
+        this.orderCompleteResponseDtos = orderCompleteResponseDtos;
+    }
+
+
+    public static MemberInfoResponse fromEntity(Member member) {
+        return new MemberInfoResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getPassword(),
+                member.getName(),
+                member.getBirthDate(),
+                member.getField(),
+                member.getPhoneNum(),
+                member.isNative(),
+                member.isServiceAccept(),
+                member.getUser_registered_at(),
+                member.getOrders().stream().map(OrderResponse.OrderCompleteResponseDto::response).toList()
+        );
+    }
+}

--- a/server/src/main/java/com/onetool/server/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/onetool/server/member/repository/MemberRepository.java
@@ -18,4 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM Member m LEFT JOIN FETCH m.cart WHERE m.id = :id")
     Optional<Member> findByIdWithCart(@Param("id") Long id);
+
+    Optional<Member> findByNameAndPhoneNum(String name, String phoneNum);
 }

--- a/server/src/main/java/com/onetool/server/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/service/MemberService.java
@@ -155,4 +155,11 @@ public class MemberService {
             throw new BusinessLogicException();
         }
     }
+
+    public MemberInfoResponse getMemberInfo(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("회원 정보가 존재하지 않습니다."));
+
+        return MemberInfoResponse.fromEntity(member);
+    }
 }

--- a/server/src/main/java/com/onetool/server/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/service/MemberService.java
@@ -70,6 +70,16 @@ public class MemberService {
         return jwtUtil.create(context);
     }
 
+    public String findEmail(MemberFindEmailRequest request) {
+        String name = request.name();
+        String phoneNum = request.phone_num();
+
+        Member member = memberRepository.findByNameAndPhoneNum(name, phoneNum)
+                .orElseThrow(() -> new RuntimeException("회원 정보가 존재하지 않습니다."));
+
+        return member.getEmail();
+    }
+
     public void sendCodeToEmail(String toEmail) {
         this.checkDuplicatedEmail(toEmail);
         String title = "Travel with me 이메일 인증 번호";

--- a/server/src/main/java/com/onetool/server/order/Orders.java
+++ b/server/src/main/java/com/onetool/server/order/Orders.java
@@ -1,6 +1,7 @@
 package com.onetool.server.order;
 
 import com.onetool.server.global.entity.BaseEntity;
+import com.onetool.server.member.domain.Member;
 import com.onetool.server.payments.Payments;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -24,6 +25,11 @@ public class Orders extends BaseEntity {
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderBlueprint> orderItems = new ArrayList<>();
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_member_id")
+    private Member member;
 
     @OneToOne
     private Payments payments;

--- a/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
+++ b/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
@@ -144,4 +144,46 @@ public class MemberServiceTest {
         assertThat(memberResponse.jsonPath().getBoolean("isNative")).isTrue();
         assertThat(memberResponse.jsonPath().getString("user_registered_at")).isEqualTo(LocalDate.now().toString());
     }
+
+    @Test
+    @DisplayName("이름과 전화번호를 통한 이메일 찾기 성공 테스트")
+    void findEmailSuccess() {
+        // Step 1: Sign up the user
+        final Map<String, Object> signupParams = Map.of(
+                "email", "admin@example.com",
+                "password", "1234",
+                "name", "홍길동",
+                "birthDate", "2001-03-26",
+                "development_field", "백엔드",
+                "phoneNum", "01000000000",
+                "isNative", true
+        );
+
+        // 회원 가입 요청
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(signupParams)
+                .when().post("/users/signup")
+                .then().log().all()
+                .statusCode(201);
+
+        final Map<String, Object> findEmailParams = Map.of(
+                "name", "홍길동",
+                "phone_num", "01000000000"
+        );
+
+        // 이메일 찾기 요청
+        ExtractableResponse<Response> findEmailResponse = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(findEmailParams)
+                .when().post("/users/email")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        String expectedEmail = "admin@example.com";
+        assertThat(findEmailResponse.body().asString()).isEqualTo(expectedEmail);
+
+        System.out.println("Find email response body: " + findEmailResponse.body().asString());
+    }
 }

--- a/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
+++ b/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,5 +76,72 @@ public class MemberServiceTest {
                 () -> assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(deleteResponse.body().asString()).isEqualTo("회원 탈퇴가 완료되었습니다.")
         );
+    }
+
+    @Test
+    @DisplayName("로그인 후 회원 정보 조회 성공 테스트")
+    void loginAndGetMemberSuccess() {
+        // given (회원 가입)
+        final Map<String, Object> signupParams = Map.of(
+                "email", "admin@example.com",
+                "password", "1234",
+                "name", "홍길동",
+                "birthDate", "2001-03-26",
+                "development_field", "백엔드",
+                "phoneNum", "01000000000",
+                "isNative", true
+        );
+
+        // 회원 가입 요청
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(signupParams)
+                .when().post("/users/signup")
+                .then().log().all()
+                .statusCode(201);
+
+        // given (로그인)
+        final Map<String, String> loginParams = Map.of(
+                "email", "admin@example.com",
+                "password", "1234"
+        );
+
+        // 로그인 요청
+        ExtractableResponse<Response> loginResponse = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(loginParams)
+                .when().post("/users/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // 로그인 응답에서 Authorization 헤더 추출
+        String token = loginResponse.header("Authorization");
+        assertThat(token).isNotNull();
+
+        // 토큰에서 "Bearer " 부분 제거
+        token = token.replace("Bearer ", "").trim();
+        System.out.println("Extracted Token: " + token);
+
+        // when (회원 정보 조회)
+        ExtractableResponse<Response> memberResponse = RestAssured.given().log().all()
+                .header("Authorization", "Bearer " + token)
+                .contentType(ContentType.JSON)
+                .when().get("/users")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // 응답 본문 출력 (디버깅용)
+        System.out.println("Member response body: " + memberResponse.body().asString());
+
+        // then (조회 결과 검증)
+        assertThat(memberResponse.jsonPath().getString("email")).isEqualTo("admin@example.com");
+        assertThat(memberResponse.jsonPath().getString("name")).isEqualTo("홍길동");
+        assertThat(memberResponse.jsonPath().getString("birthDate")).isEqualTo("2001-03-26");
+        assertThat(memberResponse.jsonPath().getString("development_field")).isEqualTo("백엔드");
+        assertThat(memberResponse.jsonPath().getString("phoneNum")).isEqualTo("01000000000");
+        assertThat(memberResponse.jsonPath().getBoolean("isNative")).isTrue();
+        assertThat(memberResponse.jsonPath().getString("user_registered_at")).isEqualTo(LocalDate.now().toString());
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

-  회원 정보 조회 기능 

- 이메일 찾기를 피그마를 기반으로 이름,전화번호를 사용하도록 수정함 


<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크


<br/>