### PR TITLE
refactor: @PatchMapping를 통해서 개인정보 수정하도록 변경

### DIFF
--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -73,7 +73,7 @@ public class MemberController {
         }
     }
 
-    @PutMapping //TODO 임시, 수정해야함
+    @PatchMapping
     public ResponseEntity<String> updateMember(
             @Valid @RequestBody MemberUpdateRequest request,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {

--- a/server/src/main/java/com/onetool/server/member/domain/Member.java
+++ b/server/src/main/java/com/onetool/server/member/domain/Member.java
@@ -81,6 +81,7 @@ public class Member extends BaseEntity {
 
     @Column(name = "user_registered_at")
     private LocalDate user_registered_at;
+
     @Builder
     public Member(Long id, String password, String email, String name, LocalDate birthDate, String phoneNum, UserRole role, String field, boolean isNative, boolean serviceAccept, String platformType, SocialType socialType, String socialId, List<QnaBoard> qnaBoards, List<QnaReply> qnaReplies, Cart cart) {
         this.id = id;
@@ -98,26 +99,23 @@ public class Member extends BaseEntity {
         this.socialId = socialId;
         this.qnaBoards = qnaBoards;
         this.qnaReplies = qnaReplies;
-        this.cart = Cart.createCart(this);
+        this.cart = cart != null ? cart : Cart.createCart(this);
     }
 
     public Member updateWith(MemberUpdateRequest request) {
-        return Member.builder()
-                .id(this.id)
-                .email(request.getEmail() != null ? request.getEmail() : this.email)
-                .name(request.getName() != null ? request.getName() : this.name)
-                .birthDate(this.birthDate)
-                .field(request.getDevelopmentField() != null ? request.getDevelopmentField() : this.field)
-                .phoneNum(request.getPhoneNum() != null ? request.getPhoneNum() : this.phoneNum)
-                .isNative(this.isNative)
-                .serviceAccept(this.serviceAccept)
-                .platformType(this.platformType)
-                .socialType(this.socialType)
-                .socialId(this.socialId)
-                .qnaBoards(this.qnaBoards)
-                .qnaReplies(this.qnaReplies)
-                .cart(this.cart)
-                .build();
+        if (request.getEmail() != null) {
+            this.email = request.getEmail();
+        }
+        if (request.getName() != null) {
+            this.name = request.getName();
+        }
+        if (request.getPhoneNum() != null) {
+            this.phoneNum = request.getPhoneNum();
+        }
+        if (request.getDevelopmentField() != null) {
+            this.field = request.getDevelopmentField();
+        }
+        return this;
     }
 
     public void updatePassword(String newPassword, PasswordEncoder encoder) {

--- a/server/src/main/java/com/onetool/server/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.onetool.server.mail.MailService;
 import com.onetool.server.member.dto.*;
 import com.onetool.server.member.repository.MemberRepository;
 import com.onetool.server.member.domain.Member;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -137,12 +138,13 @@ public class MemberService {
         return true;
     }
 
-    public void updateMember(Long id, MemberUpdateRequest request) {
+    public Member updateMember(Long id, MemberUpdateRequest request) {
         Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
 
-        Member updatedMember = member.updateWith(request);
-        memberRepository.save(updatedMember);
+        member.updateWith(request);
+
+        return memberRepository.save(member);
     }
 
     public void deleteMember(Long id) {


### PR DESCRIPTION
## 🔎 작업 내용

- 유저정보 수정을 기존의 `Putmapping`에서 `PatchMapping`로 수정함

- 유저정보 수정시 cart id에 대한 충돌이 발생해 `this.cart = cart != null ? cart : Cart.createCart(this);`로 수정함 


<br/>

## 🔧 앞으로의 과제

- 우선 email도 /user를 통해 수정하도록 구현해두었으나 유저의 id를 email로 사용함
- 이를 변경이 가능하게 하도록하는게 맞는 것인지

  <br/>

## ➕ 이슈 링크


<br/>