### PR TITLE
[TIC-86] 카테고리 관련 API를 ApiResponse로 리펙터링

### DIFF
--- a/server/src/main/java/com/onetool/server/DataLoader.java
+++ b/server/src/main/java/com/onetool/server/DataLoader.java
@@ -13,9 +13,11 @@ import org.springframework.stereotype.Component;
 public class DataLoader implements CommandLineRunner {
 
     private final FirstCategoryRepository firstCategoryRepository;
+    private final BlueprintRepository blueprintRepository;
 
-    public DataLoader(FirstCategoryRepository firstCategoryRepository) {
+    public DataLoader(FirstCategoryRepository firstCategoryRepository, BlueprintRepository blueprintRepository) {
         this.firstCategoryRepository = firstCategoryRepository;
+        this.blueprintRepository = blueprintRepository;
     }
 
     @Override
@@ -61,5 +63,499 @@ public class DataLoader implements CommandLineRunner {
                         .name("etc")
                         .build()
         );
+
+        createBlueprint(
+                "건축 도면 1",
+                "주거 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "주거"
+        );
+        createBlueprint(
+                "건축 도면 2",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "주거"
+        );
+        createBlueprint(
+                "건축 도면 3",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "상업"
+        );
+        createBlueprint(
+                "건축 도면 4",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "상업"
+        );
+        createBlueprint(
+                "건축 도면 5",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "공공"
+        );
+
+        // 2. 토목도면
+
+        createBlueprint(
+                "토목 도면 1",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "도로"
+        );
+        createBlueprint(
+                "토목 도면 2",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "도로"
+        );
+        createBlueprint(
+                "토목 도면 3",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "도로"
+        );
+        createBlueprint(
+                "토목 도면 4",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "교량"
+        );
+        createBlueprint(
+                "토목 도면 5",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "교량"
+        );
+        createBlueprint(
+                "토목 도면 6",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "터널"
+        );
+        createBlueprint(
+                "토목 도면 7",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "터널"
+        );
+
+        createBlueprint(
+                "토목 도면 8",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "댐/수자원"
+        );
+        createBlueprint(
+                "토목 도면 9",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "댐/수자원"
+        );
+        createBlueprint(
+                "토목 도면 10",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "댐/수자원"
+        );
+
+        /*
+         * 3. 인테리어 도면
+         */
+        createBlueprint(
+                "인테리어 도면 1",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "주거"
+        );
+        createBlueprint(
+                "인테리어 도면 2",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "주거"
+        );
+        createBlueprint(
+                "인테리어 도면 3",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "상업"
+        );
+        createBlueprint(
+                "인테리어 도면 4",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "상업"
+        );
+        createBlueprint(
+                "인테리어 도면 5",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "상업"
+        );
+
+        createBlueprint(
+                "인테리어 도면 6",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "가구/집기"
+        );
+        createBlueprint(
+                "인테리어 도면 7",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "가구/집기"
+        );
+        createBlueprint(
+                "인테리어 도면 8",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "가구/집기"
+        );
+
+        /*
+         * 4. 기계 도면
+         */
+
+        createBlueprint(
+                "기계 도면 1",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 2",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 3",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 4",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 5",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+
+        /*
+         * 5. 전기 도면
+         */
+        createBlueprint(
+                "전기 도면 1",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 2",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 3",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 4",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 5",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+
+        /*
+         * 6. 기타 도면
+         */
+        createBlueprint(
+                "기타 도면 1",
+                "기타 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                6L,
+                null
+        );
+    }
+
+    private void createBlueprint(
+            String blueprintName,
+            String blueprintDetails,
+            String creatorName,
+            Long standardPrice,
+            Long salePrice,
+            String program,
+            String downloadLink,
+            String extension,
+            String blueprintImg,
+            Long categoryId,
+            String secondCategory
+    ) {
+        Blueprint blueprint = Blueprint.builder()
+                .blueprintName(blueprintName)
+                .blueprintDetails(blueprintDetails)
+                .creatorName(creatorName)
+                .standardPrice(standardPrice)
+                .salePrice(salePrice)
+                .program(program)
+                .downloadLink(downloadLink)
+                .extension(extension)
+                .blueprintImg(blueprintImg)
+                .categoryId(categoryId)
+                .secondCategory(secondCategory)
+                .build();
+        blueprintRepository.save(blueprint);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -38,7 +38,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()){
+        if(category == null){
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_BUILDING, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_BUILDING, category, pageable);
@@ -52,7 +52,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_CIVIL, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_CIVIL, category, pageable);
@@ -66,7 +66,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
@@ -79,7 +79,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
@@ -93,7 +93,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -3,16 +3,17 @@ package com.onetool.server.blueprint.controller;
 import com.onetool.server.blueprint.service.BlueprintService;
 import com.onetool.server.blueprint.dto.SearchResponse;
 import com.onetool.server.category.FirstCategoryType;
+import com.onetool.server.global.exception.ApiResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 public class SearchController {
 
     private BlueprintService blueprintService;
@@ -22,17 +23,17 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint")
-    public ResponseEntity searchWithKeyword(
+    public ApiResponse<?> searchWithKeyword(
             @RequestParam("s")String keyword,
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
 
         Page<SearchResponse> response = blueprintService.searchNameAndCreatorWithKeyword(keyword, pageable);
-        return ResponseEntity.ok().body(response);
+        return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("/blueprint/building")
-    public ResponseEntity searchBuildingCategory(
+    public ApiResponse<?> searchBuildingCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -42,11 +43,11 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_BUILDING, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/civil")
-    public ResponseEntity searchCivilCategory(
+    public ApiResponse<?> searchCivilCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -56,11 +57,11 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_CIVIL, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/interior")
-    public ResponseEntity searchInteriorCategory(
+    public ApiResponse<?> searchInteriorCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -70,10 +71,10 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
     @GetMapping("/blueprint/machine")
-    public ResponseEntity searchMachineCategory(
+    public ApiResponse<?> searchMachineCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -83,11 +84,11 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/electric")
-    public ResponseEntity searchElectricCategory(
+    public ApiResponse<?> searchElectricCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -97,22 +98,22 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/etc")
-    public ResponseEntity searchEtcCategory(
+    public ApiResponse<?> searchEtcCategory(
             @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
         Page<SearchResponse> responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_ETC, pageable);
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/all")
-    public ResponseEntity searchAllBlueprint(
+    public ApiResponse<?> searchAllBlueprint(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
         Page<SearchResponse> responses = blueprintService.findAll(pageable);
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -80,9 +80,9 @@ public class SearchController {
     ) {
         Page<SearchResponse> responses;
         if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
+            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_MACHINE, pageable);
         } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
+            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_MACHINE, category, pageable);
         }
         return ApiResponse.onSuccess(responses);
     }
@@ -94,9 +94,9 @@ public class SearchController {
     ) {
         Page<SearchResponse> responses;
         if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
+            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_ELECTRIC, pageable);
         } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
+            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_ELECTRIC, category, pageable);
         }
         return ApiResponse.onSuccess(responses);
     }


### PR DESCRIPTION
### 🎟️ 티켓 번호
TIC-86

## 🔎 작업 내용
- fix: 기계 카테고리, 전기 카테고리의 enum이 인테리어인 부분 해결
    - SearchController에서 findAllByFirstCategory()와 findAllBySecondCategory()의 파라미터가 CATEGORY_INTERIOR인 부분을 각각 올바르게 수정
-  fix: 카테고리 Request Parameter가 없을 경우, null 체크 코드 변경
    - isEmpty()는 ""을 구분하기 때문에, == null로 수정
- fix: 카테고리 관련 API의 응답을 ApiResponse를 이용하도록 수정
- test: Blueprint 더미데이터 34개 추가

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

<!-- [레포 이름 #이슈번호](이슈 주소) -->

<br/>
