### PR TITLE
[TIC-92] 카테고리 Controller와 Service 리팩터링

### DIFF
--- a/server/src/main/java/com/onetool/server/DataLoader.java
+++ b/server/src/main/java/com/onetool/server/DataLoader.java
@@ -13,9 +13,11 @@ import org.springframework.stereotype.Component;
 public class DataLoader implements CommandLineRunner {
 
     private final FirstCategoryRepository firstCategoryRepository;
+    private final BlueprintRepository blueprintRepository;
 
-    public DataLoader(FirstCategoryRepository firstCategoryRepository) {
+    public DataLoader(FirstCategoryRepository firstCategoryRepository, BlueprintRepository blueprintRepository) {
         this.firstCategoryRepository = firstCategoryRepository;
+        this.blueprintRepository = blueprintRepository;
     }
 
     @Override
@@ -61,5 +63,499 @@ public class DataLoader implements CommandLineRunner {
                         .name("etc")
                         .build()
         );
+
+        createBlueprint(
+                "건축 도면 1",
+                "주거 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "주거"
+        );
+        createBlueprint(
+                "건축 도면 2",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "주거"
+        );
+        createBlueprint(
+                "건축 도면 3",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "상업"
+        );
+        createBlueprint(
+                "건축 도면 4",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "상업"
+        );
+        createBlueprint(
+                "건축 도면 5",
+                "건축 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                1L,
+                "공공"
+        );
+
+        // 2. 토목도면
+
+        createBlueprint(
+                "토목 도면 1",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "도로"
+        );
+        createBlueprint(
+                "토목 도면 2",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "도로"
+        );
+        createBlueprint(
+                "토목 도면 3",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "도로"
+        );
+        createBlueprint(
+                "토목 도면 4",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "교량"
+        );
+        createBlueprint(
+                "토목 도면 5",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "교량"
+        );
+        createBlueprint(
+                "토목 도면 6",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "터널"
+        );
+        createBlueprint(
+                "토목 도면 7",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "터널"
+        );
+
+        createBlueprint(
+                "토목 도면 8",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "댐/수자원"
+        );
+        createBlueprint(
+                "토목 도면 9",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "댐/수자원"
+        );
+        createBlueprint(
+                "토목 도면 10",
+                "토목 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                2L,
+                "댐/수자원"
+        );
+
+        /*
+         * 3. 인테리어 도면
+         */
+        createBlueprint(
+                "인테리어 도면 1",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "주거"
+        );
+        createBlueprint(
+                "인테리어 도면 2",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "주거"
+        );
+        createBlueprint(
+                "인테리어 도면 3",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "상업"
+        );
+        createBlueprint(
+                "인테리어 도면 4",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "상업"
+        );
+        createBlueprint(
+                "인테리어 도면 5",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "상업"
+        );
+
+        createBlueprint(
+                "인테리어 도면 6",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "가구/집기"
+        );
+        createBlueprint(
+                "인테리어 도면 7",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "가구/집기"
+        );
+        createBlueprint(
+                "인테리어 도면 8",
+                "인테리어 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                3L,
+                "가구/집기"
+        );
+
+        /*
+         * 4. 기계 도면
+         */
+
+        createBlueprint(
+                "기계 도면 1",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 2",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 3",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 4",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+        createBlueprint(
+                "기계 도면 5",
+                "기계 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                4L,
+                "기계부품"
+        );
+
+        /*
+         * 5. 전기 도면
+         */
+        createBlueprint(
+                "전기 도면 1",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 2",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 3",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 4",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+        createBlueprint(
+                "전기 도면 5",
+                "전기 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                5L,
+                "전기"
+        );
+
+        /*
+         * 6. 기타 도면
+         */
+        createBlueprint(
+                "기타 도면 1",
+                "기타 도면에 대한 설명",
+                "원툴",
+                50000L,
+                40000L,
+                "CAD",
+                "https://onetool.com/download",
+                ".exe",
+                "https://s3.bucket.image.com/",
+                6L,
+                null
+        );
+    }
+
+    private void createBlueprint(
+            String blueprintName,
+            String blueprintDetails,
+            String creatorName,
+            Long standardPrice,
+            Long salePrice,
+            String program,
+            String downloadLink,
+            String extension,
+            String blueprintImg,
+            Long categoryId,
+            String secondCategory
+    ) {
+        Blueprint blueprint = Blueprint.builder()
+                .blueprintName(blueprintName)
+                .blueprintDetails(blueprintDetails)
+                .creatorName(creatorName)
+                .standardPrice(standardPrice)
+                .salePrice(salePrice)
+                .program(program)
+                .downloadLink(downloadLink)
+                .extension(extension)
+                .blueprintImg(blueprintImg)
+                .categoryId(categoryId)
+                .secondCategory(secondCategory)
+                .build();
+        blueprintRepository.save(blueprint);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -38,7 +38,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()){
+        if(category == null){
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_BUILDING, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_BUILDING, category, pageable);
@@ -52,7 +52,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_CIVIL, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_CIVIL, category, pageable);
@@ -66,7 +66,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
@@ -79,7 +79,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
@@ -93,7 +93,7 @@ public class SearchController {
             @RequestParam(required = false) String category
     ) {
         Page<SearchResponse> responses;
-        if(category.isEmpty()) {
+        if(category == null) {
             responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -3,16 +3,17 @@ package com.onetool.server.blueprint.controller;
 import com.onetool.server.blueprint.service.BlueprintService;
 import com.onetool.server.blueprint.dto.SearchResponse;
 import com.onetool.server.category.FirstCategoryType;
+import com.onetool.server.global.exception.ApiResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 public class SearchController {
 
     private BlueprintService blueprintService;
@@ -22,17 +23,17 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint")
-    public ResponseEntity searchWithKeyword(
+    public ApiResponse<?> searchWithKeyword(
             @RequestParam("s")String keyword,
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
 
         Page<SearchResponse> response = blueprintService.searchNameAndCreatorWithKeyword(keyword, pageable);
-        return ResponseEntity.ok().body(response);
+        return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("/blueprint/building")
-    public ResponseEntity searchBuildingCategory(
+    public ApiResponse<?> searchBuildingCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -42,11 +43,11 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_BUILDING, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/civil")
-    public ResponseEntity searchCivilCategory(
+    public ApiResponse<?> searchCivilCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -56,11 +57,11 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_CIVIL, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/interior")
-    public ResponseEntity searchInteriorCategory(
+    public ApiResponse<?> searchInteriorCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -70,10 +71,10 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
     @GetMapping("/blueprint/machine")
-    public ResponseEntity searchMachineCategory(
+    public ApiResponse<?> searchMachineCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -83,11 +84,11 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/electric")
-    public ResponseEntity searchElectricCategory(
+    public ApiResponse<?> searchElectricCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -97,22 +98,22 @@ public class SearchController {
         } else {
             responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
         }
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/etc")
-    public ResponseEntity searchEtcCategory(
+    public ApiResponse<?> searchEtcCategory(
             @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
         Page<SearchResponse> responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_ETC, pageable);
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 
     @GetMapping("/blueprint/all")
-    public ResponseEntity searchAllBlueprint(
+    public ApiResponse<?> searchAllBlueprint(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
         Page<SearchResponse> responses = blueprintService.findAll(pageable);
-        return ResponseEntity.ok().body(responses);
+        return ApiResponse.onSuccess(responses);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -37,12 +37,7 @@ public class SearchController {
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
-        Page<SearchResponse> responses;
-        if(category == null){
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_BUILDING, pageable);
-        } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_BUILDING, category, pageable);
-        }
+        Page<SearchResponse> responses = blueprintService.findAllByCategory(FirstCategoryType.CATEGORY_BUILDING, category, pageable);
         return ApiResponse.onSuccess(responses);
     }
 
@@ -51,12 +46,7 @@ public class SearchController {
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
-        Page<SearchResponse> responses;
-        if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_CIVIL, pageable);
-        } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_CIVIL, category, pageable);
-        }
+        Page<SearchResponse> responses = blueprintService.findAllByCategory(FirstCategoryType.CATEGORY_CIVIL, category, pageable);
         return ApiResponse.onSuccess(responses);
     }
 
@@ -65,12 +55,7 @@ public class SearchController {
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
-        Page<SearchResponse> responses;
-        if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
-        } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
-        }
+        Page<SearchResponse> responses = blueprintService.findAllByCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
         return ApiResponse.onSuccess(responses);
     }
     @GetMapping("/blueprint/machine")
@@ -78,12 +63,7 @@ public class SearchController {
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
-        Page<SearchResponse> responses;
-        if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_MACHINE, pageable);
-        } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_MACHINE, category, pageable);
-        }
+        Page<SearchResponse> responses = blueprintService.findAllByCategory(FirstCategoryType.CATEGORY_MACHINE, category, pageable);
         return ApiResponse.onSuccess(responses);
     }
 
@@ -92,12 +72,7 @@ public class SearchController {
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
-        Page<SearchResponse> responses;
-        if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_ELECTRIC, pageable);
-        } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_ELECTRIC, category, pageable);
-        }
+        Page<SearchResponse> responses = blueprintService.findAllByCategory(FirstCategoryType.CATEGORY_ELECTRIC, category, pageable);
         return ApiResponse.onSuccess(responses);
     }
 
@@ -105,7 +80,7 @@ public class SearchController {
     public ApiResponse<?> searchEtcCategory(
             @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
-        Page<SearchResponse> responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_ETC, pageable);
+        Page<SearchResponse> responses = blueprintService.findAllByCategory(FirstCategoryType.CATEGORY_CIVIL, null, pageable);
         return ApiResponse.onSuccess(responses);
     }
 

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -23,7 +23,7 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint")
-    public ApiResponse<?> searchWithKeyword(
+    public ApiResponse<Page<SearchResponse>> searchWithKeyword(
             @RequestParam("s")String keyword,
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
@@ -33,7 +33,7 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint/building")
-    public ApiResponse<?> searchBuildingCategory(
+    public ApiResponse<Page<SearchResponse>> searchBuildingCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -42,7 +42,7 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint/civil")
-    public ApiResponse<?> searchCivilCategory(
+    public ApiResponse<Page<SearchResponse>> searchCivilCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -51,7 +51,7 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint/interior")
-    public ApiResponse<?> searchInteriorCategory(
+    public ApiResponse<Page<SearchResponse>> searchInteriorCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -59,7 +59,7 @@ public class SearchController {
         return ApiResponse.onSuccess(responses);
     }
     @GetMapping("/blueprint/machine")
-    public ApiResponse<?> searchMachineCategory(
+    public ApiResponse<Page<SearchResponse>> searchMachineCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -68,7 +68,7 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint/electric")
-    public ApiResponse<?> searchElectricCategory(
+    public ApiResponse<Page<SearchResponse>> searchElectricCategory(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable,
             @RequestParam(required = false) String category
     ) {
@@ -77,7 +77,7 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint/etc")
-    public ApiResponse<?> searchEtcCategory(
+    public ApiResponse<Page<SearchResponse>> searchEtcCategory(
             @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
         Page<SearchResponse> responses = blueprintService.findAllByCategory(FirstCategoryType.CATEGORY_CIVIL, null, pageable);
@@ -85,7 +85,7 @@ public class SearchController {
     }
 
     @GetMapping("/blueprint/all")
-    public ApiResponse<?> searchAllBlueprint(
+    public ApiResponse<Page<SearchResponse>> searchAllBlueprint(
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
         Page<SearchResponse> responses = blueprintService.findAll(pageable);

--- a/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/SearchController.java
@@ -80,9 +80,9 @@ public class SearchController {
     ) {
         Page<SearchResponse> responses;
         if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
+            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_MACHINE, pageable);
         } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
+            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_MACHINE, category, pageable);
         }
         return ApiResponse.onSuccess(responses);
     }
@@ -94,9 +94,9 @@ public class SearchController {
     ) {
         Page<SearchResponse> responses;
         if(category == null) {
-            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_INTERIOR, pageable);
+            responses = blueprintService.findAllByFirstCategory(FirstCategoryType.CATEGORY_ELECTRIC, pageable);
         } else {
-            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_INTERIOR, category, pageable);
+            responses = blueprintService.findAllBySecondCategory(FirstCategoryType.CATEGORY_ELECTRIC, category, pageable);
         }
         return ApiResponse.onSuccess(responses);
     }

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -104,7 +104,22 @@ public class BlueprintService {
         return new PageImpl<>(list, pageable, result.getTotalElements());
     }
 
-    public Page<SearchResponse> findAllByFirstCategory(FirstCategoryType category, Pageable pageable) {
+    public Page<SearchResponse> findAllByCategory(FirstCategoryType firstCategory, String secondCategory, Pageable pageable) {
+        if(secondCategory == null) {
+            return findAllByFirstCategory(firstCategory, pageable);
+        }
+        return findAllBySecondCategory(firstCategory, secondCategory, pageable);
+    }
+
+    public Page<SearchResponse> findAll(Pageable pageable) {
+        Page<Blueprint> result = blueprintRepository.findAll(pageable);
+        List<SearchResponse> list = result.getContent().stream()
+                .map(SearchResponse::from)
+                .collect(Collectors.toList());
+        return new PageImpl<>(list, pageable, result.getTotalElements());
+    }
+
+    private Page<SearchResponse> findAllByFirstCategory(FirstCategoryType category, Pageable pageable) {
         Page<Blueprint> result = blueprintRepository.findAllByFirstCategory(category.getType(), pageable);
         List<SearchResponse> list = result.getContent().stream()
                 .map(SearchResponse::from)
@@ -112,17 +127,9 @@ public class BlueprintService {
         return new PageImpl<>(list, pageable, result.getTotalElements());
     }
 
-    public Page<SearchResponse> findAllBySecondCategory(FirstCategoryType firstCategory, String secondCategory, Pageable pageable) {
+    private Page<SearchResponse> findAllBySecondCategory(FirstCategoryType firstCategory, String secondCategory, Pageable pageable) {
         Page<Blueprint> result = blueprintRepository.findAllBySecondCategory(
                 firstCategory.getType(), secondCategory, pageable);
-        List<SearchResponse> list = result.getContent().stream()
-                .map(SearchResponse::from)
-                .collect(Collectors.toList());
-        return new PageImpl<>(list, pageable, result.getTotalElements());
-    }
-
-    public Page<SearchResponse> findAll(Pageable pageable) {
-        Page<Blueprint> result = blueprintRepository.findAll(pageable);
         List<SearchResponse> list = result.getContent().stream()
                 .map(SearchResponse::from)
                 .collect(Collectors.toList());


### PR DESCRIPTION
### 🎟️ 티켓 번호
TIC-92

## 🔎 작업 내용
### fix: 1차 카테고리와 2차 카테고리 구분 로직을 서비스로 이동
- Controller에서 if-else를 이용한 null 구분을 Service에서 처리하도록 수정
- 기존에 else문을 삭제하고 return을 사용하도록 수정
- 기존 findAllByfirstCategory와 findAllBySecondCateogry를 private으로 전환.
- 새로운 findAllCategory를 사용하여 2차 카테고리 null 구분 후, 알맞은 메서드 선택

### fix: ApiResponse 반환의 지네릭 타입을 와일드 카드 대신 구체적으로 명시
- 기존 ?을 반환 타입에 맞게 구체적으로 수정

<br/>

## 🔧 앞으로의 과제
- refresh Token 구현

  <br/>

## ➕ 관련 링크
[PR#49](https://github.com/likelion-onetool/backend/pull/49)
<!-- [레포 이름 #이슈번호](이슈 주소) -->

<br/>
