### PR TITLE
[TIC-90] feat: Blueprint 상품 정렬 방식 변경

### DIFF
--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -11,6 +11,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/blueprint")
 public class BlueprintController {
+
     @Autowired
     private BlueprintService blueprintService;
 

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -27,13 +27,13 @@ public class BlueprintController {
     }
 
     @PutMapping("/update")
-    public ApiResponse<?> updateBlueprint(@RequestBody BlueprintResponse blueprintResponse) {
+    public ApiResponse<String> updateBlueprint(@RequestBody BlueprintResponse blueprintResponse) {
         blueprintService.updateBlueprint(blueprintResponse);
         return ApiResponse.onSuccess("상품이 정상적으로 수정 되었습니다.");
     }
 
     @DeleteMapping("/delete/{id}")
-    public ApiResponse<?> deleteBlueprint(@PathVariable Long id){
+    public ApiResponse<String> deleteBlueprint(@PathVariable Long id){
         blueprintService.deleteBlueprint(id);
         return ApiResponse.onSuccess("상품이 정상적으로 삭제 되었습니다.");
     }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -6,6 +6,8 @@ import com.onetool.server.global.exception.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/blueprint")
 public class BlueprintController {
@@ -34,5 +36,11 @@ public class BlueprintController {
     public ApiResponse<?> deleteBlueprint(@PathVariable Long id){
         blueprintService.deleteBlueprint(id);
         return ApiResponse.onSuccess("상품이 정상적으로 삭제 되었습니다.");
+    }
+
+    @GetMapping("/sort")
+    public ApiResponse<List<BlueprintResponse>> sortBlueprints(@RequestParam String sortBy) {
+        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprints(sortBy);
+        return ApiResponse.onSuccess(sortedBlueprints);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -31,7 +31,6 @@ public class BlueprintService {
         return BlueprintResponse.fromEntity(blueprint);
     }
 
-
     public boolean createBlueprint(final BlueprintRequest blueprintRequest) {
         Blueprint blueprint = convertToBlueprint(blueprintRequest);
         saveBlueprint(blueprint);


### PR DESCRIPTION
# 🎟️ 티켓 번호
TIC-90

## 🔎 작업 내용

**Feat: Blueprint 상품 정렬 방식 변경 API 구현** 

- price / createdAt / extension 에 따라 상품이 정렬 될 수 있도록 함 ( 우선 판매량 (salesCount)에 대한 정렬은 X) 

**Refactor: BlueprintService와 BlueprintController에서 컨벤션 지키도록 수정**

- BlueprintService에서 switch문을 사용하는 대신 단순하게 retrun하도록 변경 
- BlueprintService에서 indent를 지키도록 메서드를 분리 
- BlueprintController에서 <?> 와일드 카드 대신 <String> 사용하도록 수정
- 기타 컨벤션 수정

<br/>

## 🔧 앞으로의 과제

- 추가된 데이터베이스 기반으로 테스트 진행하기 
- 판매량은 처리에 대한 문제 해결

  <br/>

## ➕ 이슈 링크


<br/>
