### PR TITLE
[TIC-90] feat: Blueprint 상품 정렬 방식 변경

### DIFF
--- a/server/src/main/java/com/onetool/server/blueprint/Blueprint.java
+++ b/server/src/main/java/com/onetool/server/blueprint/Blueprint.java
@@ -1,5 +1,6 @@
 package com.onetool.server.blueprint;
 
+import com.onetool.server.blueprint.dto.BlueprintRequest;
 import com.onetool.server.cart.CartBlueprint;
 import com.onetool.server.global.entity.BaseEntity;
 import com.onetool.server.order.OrderBlueprint;
@@ -71,5 +72,23 @@ public class Blueprint extends BaseEntity {
         this.creatorName = creatorName;
         this.downloadLink = downloadLink;
         this.secondCategory = secondCategory;
+    }
+
+    public static Blueprint fromRequest(final BlueprintRequest blueprintRequest) {
+        return Blueprint.builder()
+                .id(blueprintRequest.id())
+                .blueprintName(blueprintRequest.blueprintName())
+                .categoryId(blueprintRequest.categoryId())
+                .standardPrice(blueprintRequest.standardPrice())
+                .blueprintImg(blueprintRequest.blueprintImg())
+                .blueprintDetails(blueprintRequest.blueprintDetails())
+                .extension(blueprintRequest.extension())
+                .program(blueprintRequest.program())
+                .hits(blueprintRequest.hits())
+                .salePrice(blueprintRequest.salePrice())
+                .saleExpiredDate(blueprintRequest.saleExpiredDate())
+                .creatorName(blueprintRequest.creatorName())
+                .downloadLink(blueprintRequest.downloadLink())
+                .build();
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -11,6 +11,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/blueprint")
 public class BlueprintController {
+
     @Autowired
     private BlueprintService blueprintService;
 

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -27,13 +27,13 @@ public class BlueprintController {
     }
 
     @PutMapping("/update")
-    public ApiResponse<?> updateBlueprint(@RequestBody BlueprintResponse blueprintResponse) {
+    public ApiResponse<String> updateBlueprint(@RequestBody BlueprintResponse blueprintResponse) {
         blueprintService.updateBlueprint(blueprintResponse);
         return ApiResponse.onSuccess("상품이 정상적으로 수정 되었습니다.");
     }
 
     @DeleteMapping("/delete/{id}")
-    public ApiResponse<?> deleteBlueprint(@PathVariable Long id){
+    public ApiResponse<String> deleteBlueprint(@PathVariable Long id){
         blueprintService.deleteBlueprint(id);
         return ApiResponse.onSuccess("상품이 정상적으로 삭제 되었습니다.");
     }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -5,6 +5,8 @@ import com.onetool.server.blueprint.dto.BlueprintRequest;
 import com.onetool.server.blueprint.dto.BlueprintResponse;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
+import com.onetool.server.global.exception.InvalidSortTypeException;
+import com.onetool.server.global.exception.MemberNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,7 +21,12 @@ public class BlueprintController {
     private BlueprintService blueprintService;
 
     @PostMapping("/upload")
-    public ApiResponse<String> createBlueprint(@RequestBody BlueprintRequest blueprintRequest) {
+    public ApiResponse<String> createBlueprint(@RequestBody BlueprintRequest blueprintRequest,
+                                               @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        if(principalDetails == null) {
+            throw new MemberNotFoundException();
+        }
+
        blueprintService.createBlueprint(blueprintRequest);
        return ApiResponse.onSuccess("상품이 정상적으로 등록되었습니다.");
     }
@@ -31,13 +38,23 @@ public class BlueprintController {
     }
 
     @PutMapping("/update")
-    public ApiResponse<String> updateBlueprint(@RequestBody BlueprintResponse blueprintResponse) {
+    public ApiResponse<String> updateBlueprint(@RequestBody BlueprintResponse blueprintResponse,
+                                               @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        if(principalDetails == null) {
+            throw new MemberNotFoundException();
+        }
+
         blueprintService.updateBlueprint(blueprintResponse);
         return ApiResponse.onSuccess("상품이 정상적으로 수정 되었습니다.");
     }
 
     @DeleteMapping("/delete/{id}")
-    public ApiResponse<String> deleteBlueprint(@PathVariable Long id){
+    public ApiResponse<String> deleteBlueprint(@PathVariable Long id,
+                                               @AuthenticationPrincipal PrincipalDetails principalDetails){
+        if(principalDetails == null) {
+            throw new MemberNotFoundException();
+        }
+
         blueprintService.deleteBlueprint(id);
         return ApiResponse.onSuccess("상품이 정상적으로 삭제 되었습니다.");
     }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -61,9 +61,7 @@ public class BlueprintController {
 
     @GetMapping("/sort")
     public ApiResponse<List<BlueprintResponse>> sortBlueprints(@RequestParam String sortBy) {
-        SortType sortType = SortType.valueOf(sortBy.toUpperCase());
-
-        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprints(sortType);
+        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprints(sortBy);
         return ApiResponse.onSuccess(sortedBlueprints);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -1,9 +1,12 @@
 package com.onetool.server.blueprint.controller;
+import com.onetool.server.blueprint.enums.SortType;
 import com.onetool.server.blueprint.service.BlueprintService;
 import com.onetool.server.blueprint.dto.BlueprintRequest;
 import com.onetool.server.blueprint.dto.BlueprintResponse;
+import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -41,7 +44,9 @@ public class BlueprintController {
 
     @GetMapping("/sort")
     public ApiResponse<List<BlueprintResponse>> sortBlueprints(@RequestParam String sortBy) {
-        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprints(sortBy);
+        SortType sortType = SortType.valueOf(sortBy.toUpperCase());
+
+        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprints(sortType);
         return ApiResponse.onSuccess(sortedBlueprints);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -6,6 +6,8 @@ import com.onetool.server.global.exception.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/blueprint")
 public class BlueprintController {
@@ -34,5 +36,11 @@ public class BlueprintController {
     public ApiResponse<?> deleteBlueprint(@PathVariable Long id){
         blueprintService.deleteBlueprint(id);
         return ApiResponse.onSuccess("상품이 정상적으로 삭제 되었습니다.");
+    }
+
+    @GetMapping("/sort")
+    public ApiResponse<List<BlueprintResponse>> sortBlueprints(@RequestParam String sortBy) {
+        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprints(sortBy);
+        return ApiResponse.onSuccess(sortedBlueprints);
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintRequest.java
+++ b/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintRequest.java
@@ -22,7 +22,7 @@ public record BlueprintRequest(
         String downloadLink
 )  {
     @Builder
-    public static BlueprintRequest fromEntity(Blueprint blueprint) {
+    public static BlueprintRequest from(Blueprint blueprint) {
         return new BlueprintRequest(
                 blueprint.getId(),
                 blueprint.getBlueprintName(),

--- a/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintResponse.java
+++ b/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintResponse.java
@@ -23,7 +23,7 @@ public record BlueprintResponse(
         String downloadLink
 )  {
     @Builder
-    public static BlueprintResponse fromEntity(Blueprint blueprint) {
+    public static BlueprintResponse from(Blueprint blueprint) {
         return new BlueprintResponse(
                 blueprint.getId(),
                 blueprint.getBlueprintName(),

--- a/server/src/main/java/com/onetool/server/blueprint/enums/SortType.java
+++ b/server/src/main/java/com/onetool/server/blueprint/enums/SortType.java
@@ -1,0 +1,7 @@
+package com.onetool.server.blueprint.enums;
+
+public enum SortType {
+        PRICE,
+        CREATED_AT,
+        EXTENSION
+}

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -102,22 +102,8 @@ public class BlueprintService {
                 .collect(Collectors.toList());
     }
 
-    private Blueprint convertToBlueprint(BlueprintRequest blueprintRequest) {
-        return Blueprint.builder()
-                .id(blueprintRequest.id())
-                .blueprintName(blueprintRequest.blueprintName())
-                .categoryId(blueprintRequest.categoryId())
-                .standardPrice(blueprintRequest.standardPrice())
-                .blueprintImg(blueprintRequest.blueprintImg())
-                .blueprintDetails(blueprintRequest.blueprintDetails())
-                .extension(blueprintRequest.extension())
-                .program(blueprintRequest.program())
-                .hits(blueprintRequest.hits())
-                .salePrice(blueprintRequest.salePrice())
-                .saleExpiredDate(blueprintRequest.saleExpiredDate())
-                .creatorName(blueprintRequest.creatorName())
-                .downloadLink(blueprintRequest.downloadLink())
-                .build();
+    private Blueprint convertToBlueprint(final BlueprintRequest blueprintRequest) {
+        return Blueprint.fromRequest(blueprintRequest);
     }
 
     private Blueprint updateExistingBlueprint(Blueprint existingBlueprint, BlueprintResponse blueprintResponse) {

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -6,6 +6,7 @@ import com.onetool.server.blueprint.dto.BlueprintRequest;
 import com.onetool.server.blueprint.dto.BlueprintResponse;
 import com.onetool.server.blueprint.dto.SearchResponse;
 import com.onetool.server.category.FirstCategoryType;
+import com.onetool.server.global.exception.BlueprintNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -27,7 +28,8 @@ public class BlueprintService {
 
     public BlueprintResponse findBlueprintById(Long id) {
         Blueprint blueprint = blueprintRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Blueprint not found with id: " + id));
+                .orElseThrow(BlueprintNotFoundException::new);
+
         return BlueprintResponse.fromEntity(blueprint);
     }
 
@@ -43,13 +45,14 @@ public class BlueprintService {
 
     public boolean updateBlueprint(BlueprintResponse blueprintResponse) {
         Blueprint existingBlueprint = blueprintRepository.findById(blueprintResponse.id())
-                .orElseThrow(() -> new RuntimeException("Blueprint not found with id: " + blueprintResponse.id()));
+                .orElseThrow(BlueprintNotFoundException::new);
         Blueprint updatedBlueprint = updateExistingBlueprint(existingBlueprint, blueprintResponse);
+
         saveBlueprint(updatedBlueprint);
         return true;
     }
 
-    public boolean deleteBlueprint(Long id){
+    public boolean deleteBlueprint(Long id) {
         blueprintRepository.deleteById(id);
         return true;
     };

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -31,7 +31,6 @@ public class BlueprintService {
         return BlueprintResponse.fromEntity(blueprint);
     }
 
-
     public boolean createBlueprint(final BlueprintRequest blueprintRequest) {
         Blueprint blueprint = convertToBlueprint(blueprintRequest);
         saveBlueprint(blueprint);

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -59,7 +60,14 @@ public class BlueprintService {
         return true;
     }
 
-    public List<BlueprintResponse> sortBlueprints(SortType sortType) {
+    public List<BlueprintResponse> sortBlueprints(String sortBy) {
+        if (!isValidSortType(sortBy)) {
+            throw new InvalidSortTypeException();
+        }
+
+        SortType sortType = SortType.valueOf(sortBy.toUpperCase());
+
+
         List<Blueprint> blueprints = blueprintRepository.findAll();
 
         Comparator<Blueprint> comparator = getComparatorBySortType(sortType);
@@ -152,5 +160,10 @@ public class BlueprintService {
             return blueprint.getSalePrice().doubleValue();
         }
         return blueprint.getStandardPrice().doubleValue();
+    }
+
+    public boolean isValidSortType(String sortBy) {
+        return Arrays.stream(SortType.values())
+                .anyMatch(sortType -> sortType.name().equalsIgnoreCase(sortBy));
     }
 }

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -33,7 +33,7 @@ public class BlueprintService {
         Blueprint blueprint = blueprintRepository.findById(id)
                 .orElseThrow(BlueprintNotFoundException::new);
 
-        return BlueprintResponse.fromEntity(blueprint);
+        return BlueprintResponse.from(blueprint);
     }
 
     public boolean createBlueprint(final BlueprintRequest blueprintRequest) {
@@ -112,7 +112,7 @@ public class BlueprintService {
 
     private List<BlueprintResponse> convertToResponseList(List<Blueprint> blueprints) {
         return blueprints.stream()
-                .map(BlueprintResponse::fromEntity)
+                .map(BlueprintResponse::from)
                 .collect(Collectors.toList());
     }
 

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -1,12 +1,14 @@
 package com.onetool.server.blueprint.service;
 
 import com.onetool.server.blueprint.Blueprint;
+import com.onetool.server.blueprint.enums.SortType;
 import com.onetool.server.blueprint.repository.BlueprintRepository;
 import com.onetool.server.blueprint.dto.BlueprintRequest;
 import com.onetool.server.blueprint.dto.BlueprintResponse;
 import com.onetool.server.blueprint.dto.SearchResponse;
 import com.onetool.server.category.FirstCategoryType;
 import com.onetool.server.global.exception.BlueprintNotFoundException;
+import com.onetool.server.global.exception.InvalidSortTypeException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -55,11 +57,12 @@ public class BlueprintService {
     public boolean deleteBlueprint(Long id) {
         blueprintRepository.deleteById(id);
         return true;
-    };
+    }
 
-    public List<BlueprintResponse> sortBlueprints(String sortBy) {
+    public List<BlueprintResponse> sortBlueprints(SortType sortType) {
         List<Blueprint> blueprints = blueprintRepository.findAll();
-        Comparator<Blueprint> comparator = getComparatorBySortType(sortBy);
+
+        Comparator<Blueprint> comparator = getComparatorBySortType(sortType);
         List<Blueprint> sortedBlueprints = blueprints.stream()
                 .sorted(comparator)
                 .collect(Collectors.toList());
@@ -127,20 +130,20 @@ public class BlueprintService {
                 .build();
     }
 
-    private Comparator<Blueprint> getComparatorBySortType(String sortBy) {
-        if (sortBy.equals("price")) {
+    private Comparator<Blueprint> getComparatorBySortType(SortType sortType) {
+        if (sortType == SortType.PRICE) {
             return Comparator.comparing(this::getPrice, Comparator.nullsLast(Comparator.naturalOrder()));
         }
 
-        if (sortBy.equals("createdAt")) {
+        if (sortType == SortType.CREATED_AT) {
             return Comparator.comparing(Blueprint::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder()));
         }
 
-        if (sortBy.equals("extension")) {
+        if (sortType == SortType.EXTENSION) {
             return Comparator.comparing(Blueprint::getExtension, Comparator.nullsLast(Comparator.naturalOrder()));
         }
 
-        throw new IllegalArgumentException("Invalid sort type: " + sortBy);
+        throw new IllegalArgumentException("Invalid sort type: " + sortType);
     }
 
     private Double getPrice(Blueprint blueprint) {

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -143,7 +143,7 @@ public class BlueprintService {
             return Comparator.comparing(Blueprint::getExtension, Comparator.nullsLast(Comparator.naturalOrder()));
         }
 
-        throw new IllegalArgumentException("Invalid sort type: " + sortType);
+        throw new InvalidSortTypeException();
     }
 
     private Double getPrice(Blueprint blueprint) {

--- a/server/src/main/java/com/onetool/server/global/exception/BlueprintNotFoundException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/BlueprintNotFoundException.java
@@ -1,0 +1,6 @@
+package com.onetool.server.global.exception;
+
+public class BlueprintNotFoundException extends RuntimeException {
+    public BlueprintNotFoundException() {
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/InvalidSortTypeException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/InvalidSortTypeException.java
@@ -1,0 +1,7 @@
+package com.onetool.server.global.exception;
+
+public class InvalidSortTypeException extends RuntimeException {
+    public InvalidSortTypeException() {
+
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -2,10 +2,7 @@ package com.onetool.server.global.handler;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.onetool.server.global.exception.BaseException;
-import com.onetool.server.global.exception.ApiResponse;
-import com.onetool.server.global.exception.DuplicateMemberException;
-import com.onetool.server.global.exception.MemberNotFoundException;
+import com.onetool.server.global.exception.*;
 import com.onetool.server.global.exception.codes.ErrorCode;
 import com.onetool.server.global.exception.codes.reason.Reason;
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +47,11 @@ public class ExceptionAdvice {
         return ApiResponse.onFailure("400", "이메일이 중복됩니다.", null);
     }
 
+    @ExceptionHandler(BlueprintNotFoundException.class)
+    public ApiResponse<?> handleBlueprintNotFoundException(BlueprintNotFoundException e) {
+        return ApiResponse.onFailure("404", "도면을 찾을 수 없습니다.", null);
+    }
+    
     /**
      * 서버 에러
      * @param e

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -51,6 +51,11 @@ public class ExceptionAdvice {
     public ApiResponse<?> handleBlueprintNotFoundException(BlueprintNotFoundException e) {
         return ApiResponse.onFailure("404", "도면을 찾을 수 없습니다.", null);
     }
+
+    @ExceptionHandler(InvalidSortTypeException.class)
+    public ApiResponse<?> handleInvalidSortTypeException(InvalidSortTypeException e) {
+        return ApiResponse.onFailure("404", "올바르지 않은 정렬 방식입니다.", null);
+    }
     
     /**
      * 서버 에러

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -54,7 +54,7 @@ public class ExceptionAdvice {
 
     @ExceptionHandler(InvalidSortTypeException.class)
     public ApiResponse<?> handleInvalidSortTypeException(InvalidSortTypeException e) {
-        return ApiResponse.onFailure("404", "올바르지 않은 정렬 방식입니다.", null);
+        return ApiResponse.onFailure("400", "올바르지 않은 정렬 방식입니다.", null);
     }
     
     /**


### PR DESCRIPTION
# 🎟️ 티켓 번호
TIC-90
TIC-97

## 🔎 작업 내용

### feat: Blueprint 상품 정렬 방식 변경 API 구현

- `price` / `createdAt` / `extension` 에 따라 상품이 정렬 될 수 있도록 함 ( 우선 판매량 (salesCount)에 대한 정렬은 X) 

### refactor: BlueprintService와 BlueprintController에서 컨벤션 지키도록 수정

- `BlueprintService`에서 switch문을 사용하는 대신 단순하게 retrun하도록 변경 
- `BlueprintService`에서 indent를 지키도록 메서드를 분리 
- `BlueprintController`에서 <?> 와일드 카드 대신 <String> 사용하도록 수정
- 기타 컨벤션 수정

<br/>

## 🔧 앞으로의 과제

- 추가된 데이터베이스 기반으로 테스트 진행하기 
- 판매량은 처리에 대한 문제 해결

  <br/>

## ➕ 이슈 링크


<br/>

++) 이전에 실수로 branch를 main으로 요청해서 다시 pr 보냅니다! 