### PR TITLE
[TIC-94] feat: 다운로드 가능 자료 조회 구현 

### DIFF
--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -136,5 +136,4 @@ public class MemberController {
         List<BlueprintDownloadResponse> blueprints = memberService.getPurchasedBlueprints(userId);
         return ApiResponse.onSuccess(blueprints);
     }
-
 }

--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -129,4 +129,12 @@ public class MemberController {
     public ApiResponse<List<QnaBoardResponse.QnaBoardBriefResponse>> getMyQna(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         return ApiResponse.onSuccess(memberService.findQnaWrittenById(principalDetails.getContext()));
     }
+
+    @GetMapping("/myPurchase")
+    public ApiResponse<List<BlueprintDownloadResponse>> getMyPurchases(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long userId = principalDetails.getContext().getId();
+        List<BlueprintDownloadResponse> blueprints = memberService.getPurchasedBlueprints(userId);
+        return ApiResponse.onSuccess(blueprints);
+    }
+
 }

--- a/server/src/main/java/com/onetool/server/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/member/controller/MemberController.java
@@ -123,7 +123,6 @@ public class MemberController {
         }
     }
 
-
     // TODO : uri 수정 필요
     @GetMapping("/myPage/myQna")
     public ApiResponse<List<QnaBoardResponse.QnaBoardBriefResponse>> getMyQna(@AuthenticationPrincipal PrincipalDetails principalDetails) {

--- a/server/src/main/java/com/onetool/server/member/dto/BlueprintDownloadResponse.java
+++ b/server/src/main/java/com/onetool/server/member/dto/BlueprintDownloadResponse.java
@@ -1,0 +1,9 @@
+package com.onetool.server.member.dto;
+
+public record BlueprintDownloadResponse(
+        Long blueprintId,
+        String blueprintImage,
+        String blueprintDownloadLink,
+        String blueprintName,
+        String blueprintCreatorName
+) {}

--- a/server/src/main/java/com/onetool/server/member/dto/MemberInfoResponse.java
+++ b/server/src/main/java/com/onetool/server/member/dto/MemberInfoResponse.java
@@ -38,7 +38,7 @@ public record MemberInfoResponse(
     }
 
 
-    public static MemberInfoResponse fromEntity(Member member) {
+    public static MemberInfoResponse from(Member member) {
         return new MemberInfoResponse(
                 member.getId(),
                 member.getEmail(),

--- a/server/src/main/java/com/onetool/server/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/service/MemberService.java
@@ -186,7 +186,7 @@ public class MemberService {
         Member member = memberRepository.findById(userId)
                 .orElseThrow(MemberNotFoundException::new);
 
-        return MemberInfoResponse.fromEntity(member);
+        return MemberInfoResponse.from(member);
     }
 
     public List<QnaBoardBriefResponse> findQnaWrittenById(MemberAuthContext context){

--- a/server/src/main/java/com/onetool/server/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/member/service/MemberService.java
@@ -154,7 +154,7 @@ public class MemberService {
 
     public Member updateMember(Long id, MemberUpdateRequest request) {
         Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+                .orElseThrow(MemberNotFoundException::new);
 
         member.updateWith(request);
 
@@ -163,7 +163,7 @@ public class MemberService {
 
     public void deleteMember(Long id) {
         Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(MemberNotFoundException::new);
         memberRepository.delete(member);
     }
 
@@ -184,7 +184,7 @@ public class MemberService {
 
     public MemberInfoResponse getMemberInfo(Long userId) {
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("회원 정보가 존재하지 않습니다."));
+                .orElseThrow(MemberNotFoundException::new);
 
         return MemberInfoResponse.fromEntity(member);
     }
@@ -202,7 +202,7 @@ public class MemberService {
 
     public List<BlueprintDownloadResponse> getPurchasedBlueprints(final Long userId) {
         final Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new MemberNotFoundException());
+                .orElseThrow(MemberNotFoundException::new);
 
         return member.getOrders().stream()
                 .flatMap(order -> order.getOrderItems().stream())

--- a/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
+++ b/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
@@ -257,4 +257,45 @@ public class MemberServiceTest {
         assertThat(memberResponse.jsonPath().getString("user_registered_at")).isEqualTo(LocalDate.now().toString());
     }
 
+    @Test
+    @DisplayName("유저의 구매 내역을 조회하면 정상적으로 응답한다")
+    void 유저의_구매내역을_조회하면_정상적으로_응답한다() {
+        // given (회원 가입 및 로그인)
+        final Map<String, String> loginParams = Map.of(
+                "email", "admin@example.com",
+                "password", "1234"
+        );
+
+        // 로그인 요청
+        ExtractableResponse<Response> loginResponse = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(loginParams)
+                .when().post("/users/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // 로그인 응답에서 Authorization 헤더 추출
+        String token = loginResponse.header("Authorization");
+        assertThat(token).isNotNull();
+        token = token.replace("Bearer ", "").trim();
+
+
+        // when (구매 내역 조회 요청)
+        ExtractableResponse<Response> purchaseResponse = RestAssured.given().log().all()
+                .header("Authorization", "Bearer " + token)
+                .contentType(ContentType.JSON)
+                .when().get("/users/1/myPurchase") // 적절한 userId를 사용하세요
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // 응답 본문 출력
+        System.out.println("Purchase response body: " + purchaseResponse.body().asString());
+
+        // then
+        assertThat(purchaseResponse.jsonPath().getBoolean("isSuccess")).isTrue();
+        assertThat(purchaseResponse.jsonPath().getString("code")).isEqualTo("SUCCESS-0000");
+        assertThat(purchaseResponse.jsonPath().getString("message")).isEqualTo("요청에 성공하였습니다.");
+    }
 }


### PR DESCRIPTION
# 🎟️ 티켓 번호
TIC-94

## 🔎 작업 내용
### feat:  다운 가능한 자료 조회 API 구현 

- @AuthenticationPrincipal을 통해 로그인 한 사용자가 다운 가능한 자료 조회 기능 구현
- 사용자 id 기반으로 주문내역(order)을 불러온 후 `BlueprintDownloadResponse` 객체 리스트로 반환

### test : 다운 가능한 자료 조회 API가 정상적으로 응답하는지 TEST

- 구매내역 기반으로 다운로드 가능한 상품을 조회했을 때 올바르게 api가 응답하는지 TEST
- 실제 구매에 대한 TEST데이터를 넣지 못하여 임시로 API 응답이 정상적으로 반환되는지 TEST진행

### refactor: MemberService 예외 처리 변경/ 컨벤션 수정

- 존재하는 회원에 대한 runtime 에러로 처리했던 것을 커스텀 에러로 변경
-` MemberInfoResponse` DTO 변환 메서드의 네이밍 컨벤션을 `fromEntity`에서 `from`으로 변경

---
-  코드에서 불필요하거나 더 좋은 방법이 있다면 반영하겠습니다! 

- 최대한 컨벤션 규칙을 적용해서 진행했습니다. 혹시 어긋난 것들 있으면 말씀해 주시면 반영하겠습니다!

- Mypage 기능인 qna 내역과 다운로드 내역 조회가 모두 MemberController에 개발이 되고 있는데요.
점점 헤비 해지는 느낌이라 mypage에 대한 내용을 분리하는 게 좋을지 아니면 이대로 가도 좋을지 의견이 궁금합니다!

<br/>

## 🔧 앞으로의 과제

- 추후에 결제 기능이 구현되면 정상적으로 작동하는지 추가적인 test가 필요할 것 같습니다.

  <br/>

## ➕ 이슈 링크

<br/>
