### PR TITLE
[TIC-101,102] feat: 자정마다 검수가 완료된 도면 새로고침 구현/ 검수 완료된 도면만 불러오도록 수정

### DIFF
--- a/server/src/main/java/com/onetool/server/ServerApplication.java
+++ b/server/src/main/java/com/onetool/server/ServerApplication.java
@@ -2,8 +2,10 @@ package com.onetool.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintController.java
@@ -33,7 +33,7 @@ public class BlueprintController {
 
     @GetMapping("/{id}")
     public ApiResponse<BlueprintResponse> getBlueprintDetails(@PathVariable Long id) {
-        BlueprintResponse blueprintResponseDTO = blueprintService.findBlueprintById(id);
+        BlueprintResponse blueprintResponseDTO = blueprintService.findApprovedBlueprintById(id);
         return ApiResponse.onSuccess(blueprintResponseDTO);
     }
 

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintInspectionService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintInspectionService.java
@@ -25,7 +25,7 @@ public class BlueprintInspectionService {
         List<Blueprint> blueprints = blueprintRepository.findByInspectionStatus(InspectionStatus.NONE);
 
         return blueprints.stream()
-                .map(BlueprintResponse::fromEntity)
+                .map(BlueprintResponse::from)
                 .collect(Collectors.toList());
     }
 

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintRefreshService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintRefreshService.java
@@ -1,0 +1,38 @@
+package com.onetool.server.blueprint.service;
+
+import com.onetool.server.blueprint.Blueprint;
+import com.onetool.server.blueprint.InspectionStatus;
+import com.onetool.server.blueprint.repository.BlueprintRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BlueprintRefreshService {
+
+    private final BlueprintRepository blueprintRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")  // 매일 자정 새로고침
+    public void refreshApprovedBlueprints() {
+        log.info("Refreshing approved blueprints at midnight...");
+
+        List<Blueprint> approvedBlueprints = blueprintRepository.findByInspectionStatus(InspectionStatus.PASSED);
+
+        refreshBlueprints(approvedBlueprints);
+    }
+
+    @Transactional
+    private void refreshBlueprints(List<Blueprint> blueprints) {
+        for (Blueprint blueprint : blueprints) {
+            log.info("Refreshing blueprint: {}", blueprint.getId());
+        }
+
+        //TODO 필요한 로직 추가
+    }
+}

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintService.java
@@ -1,12 +1,14 @@
 package com.onetool.server.blueprint.service;
 
 import com.onetool.server.blueprint.Blueprint;
+import com.onetool.server.blueprint.InspectionStatus;
 import com.onetool.server.blueprint.enums.SortType;
 import com.onetool.server.blueprint.repository.BlueprintRepository;
 import com.onetool.server.blueprint.dto.BlueprintRequest;
 import com.onetool.server.blueprint.dto.BlueprintResponse;
 import com.onetool.server.blueprint.dto.SearchResponse;
 import com.onetool.server.category.FirstCategoryType;
+import com.onetool.server.global.exception.BlueprintNotApprovedException;
 import com.onetool.server.global.exception.BlueprintNotFoundException;
 import com.onetool.server.global.exception.InvalidSortTypeException;
 import org.springframework.data.domain.Page;
@@ -29,17 +31,21 @@ public class BlueprintService {
         this.blueprintRepository = blueprintRepository;
     }
 
-    public BlueprintResponse findBlueprintById(Long id) {
-        Blueprint blueprint = blueprintRepository.findById(id)
-                .orElseThrow(BlueprintNotFoundException::new);
-
-        return BlueprintResponse.from(blueprint);
-    }
-
     public boolean createBlueprint(final BlueprintRequest blueprintRequest) {
         Blueprint blueprint = convertToBlueprint(blueprintRequest);
         saveBlueprint(blueprint);
         return true;
+    }
+
+    public BlueprintResponse findApprovedBlueprintById(Long id) {
+        Blueprint blueprint = blueprintRepository.findById(id)
+                .orElseThrow(BlueprintNotFoundException::new);
+
+        if (blueprint.getInspectionStatus() != InspectionStatus.PASSED) {
+            throw new BlueprintNotApprovedException();
+        }
+
+        return BlueprintResponse.from(blueprint);
     }
 
     public Blueprint saveBlueprint(Blueprint blueprint) {
@@ -66,7 +72,6 @@ public class BlueprintService {
         }
 
         SortType sortType = SortType.valueOf(sortBy.toUpperCase());
-
 
         List<Blueprint> blueprints = blueprintRepository.findAll();
 

--- a/server/src/main/java/com/onetool/server/global/exception/BlueprintNotApprovedException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/BlueprintNotApprovedException.java
@@ -1,0 +1,6 @@
+package com.onetool.server.global.exception;
+
+public class BlueprintNotApprovedException extends RuntimeException{
+    public BlueprintNotApprovedException(){
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -64,6 +64,11 @@ public class ExceptionAdvice {
         return ApiResponse.onFailure("400", "올바르지 않은 정렬 방식입니다.", null);
     }
 
+    @ExceptionHandler(BlueprintNotApprovedException.class)
+    public ApiResponse<?> BlueprintNotApprovedException(BlueprintNotApprovedException e) {
+        return ApiResponse.onFailure("403", "승인받지 않은 도면입니다.", null);
+    }
+
     /**
      * 서버 에러
      * @param e

--- a/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceTest.java
+++ b/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceTest.java
@@ -5,6 +5,7 @@ import com.onetool.server.blueprint.service.BlueprintService;
 import com.onetool.server.blueprint.dto.BlueprintRequest;
 import com.onetool.server.blueprint.dto.BlueprintResponse;
 import com.onetool.server.blueprint.dto.SearchResponse;
+import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,9 @@ public class BlueprintServiceTest {
     private BlueprintController blueprintController;
     @Autowired
     private BlueprintService blueprintService;
+
+    @Autowired
+    private PrincipalDetails principalDetails;
 
     @DisplayName("키워드 기반 검색이 잘되는지 확인")
     @Test
@@ -56,7 +60,7 @@ public class BlueprintServiceTest {
                 "https://onetool.com/download"
         );
 
-        ApiResponse<String> response = blueprintController.createBlueprint(blueprintRequest);
+        ApiResponse<String> response = blueprintController.createBlueprint(blueprintRequest, principalDetails);
 
         assertThat(response.getResult()).isEqualTo("상품이 정상적으로 등록되었습니다.");
     }
@@ -76,11 +80,12 @@ public class BlueprintServiceTest {
     public void testDeleteBlueprint() {
         Long blueprintId = 1L;
 
-        ApiResponse<?> response = blueprintController.deleteBlueprint(blueprintId);
+        ApiResponse<?> response = blueprintController.deleteBlueprint(blueprintId, principalDetails);
 
         assertThat(response.getMessage()).isEqualTo("요청에 성공하였습니다.");
         assertThat(response.getResult()).isEqualTo("상품이 정상적으로 삭제 되었습니다.");
     }
+
 
     @DisplayName("blueprint가 정상적으로 업데이트되는지 확인")
     @Test
@@ -101,7 +106,7 @@ public class BlueprintServiceTest {
                 "https://onetool.com/download"
         );
 
-        ApiResponse<?> response = blueprintController.updateBlueprint(blueprintResponse);
+        ApiResponse<?> response = blueprintController.updateBlueprint(blueprintResponse, principalDetails);
 
         assertThat(response.getMessage()).isEqualTo("요청에 성공하였습니다.");
         assertThat(response.getResult()).isEqualTo("상품이 정상적으로 수정 되었습니다.");


### PR DESCRIPTION
# 🎟️ 티켓 번호
TIC-101
TIC-102

## 🔎 작업 내용

### feat: 도면 조회 시 검수 완료된 도면만 불러오도록 변경 

- '/blueprint/{id}'로 접근시 기존의 `findBlueprintById`를 통해 id를 조회하는 방식에서 `findApprovedBlueprintById`를 통해 InspectionStatus.PASSED 검증 후, PASSED 상태인 도면만 상세페이지 조회 가능
- `BlueprintNotApprovedException`를 통해서 승인 받지 않은 도면에 접근시 403에러

[[TIC-102] 도면 조회 시 검수 완료된 도면만 불러오도록 변경](https://github.com/likelion-onetool/backend/commit/c36ef6cfed7a0940d80de00aeddcb725293106cc) 

### feat: 자정마다 검수가 완료된 도면 새로고침 하도록 구현

- `@EnableScheduling` 어노테이션을 추가
- `@Scheduled`를 통해서 매일 자정 새로고침,  매일 자정에 PASSED 상태인 도면을 조회

[[TIC-101] 자정마다 검수가 완료된 도면 새로고침 하도록 구현](https://github.com/likelion-onetool/backend/commit/355c16d64a54862d168576e1d8a4edb6ea46513b) 

<br/>

## 🔧 앞으로의 과제

- 매일 자정에 PASSED 상태인 도면을 조회 하는 것만 우선 구현, 조회 후의 진행할 로직 추가 
- 새로고침에 대한 실제 test 
- 상품 id를 통한 상세 조회 외 검색할 때도 다 승인 받지 않은 도면 거를지? 

  <br/>

## ➕ 이슈 링크


<br/>
