### PR TITLE
 🎟️  [TIC-100] 도면, 도면 상세 페이지 이미지 S3에 저장 

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,7 +24,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -45,6 +44,11 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.3.2'
+
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+	implementation 'org.apache.httpcomponents:httpcore:4.4.14'
 
 	testImplementation 'io.rest-assured:rest-assured:5.5.0'
 

--- a/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintUploadController.java
+++ b/server/src/main/java/com/onetool/server/blueprint/controller/BlueprintUploadController.java
@@ -1,0 +1,51 @@
+package com.onetool.server.blueprint.controller;
+
+import com.onetool.server.blueprint.service.BlueprintS3UploadService;
+import com.onetool.server.global.auth.login.PrincipalDetails;
+import com.onetool.server.global.exception.ApiResponse;
+import com.onetool.server.global.exception.BaseException;
+import com.onetool.server.global.exception.codes.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class BlueprintUploadController {
+
+    private final BlueprintS3UploadService blueprintS3UploadService;
+
+    // TODO : validation 추가 (팀원들과 협의 후 결정)
+    // 일단 유저 인증은 생략하고 업로드 기능만 구현
+
+    // 도면만 따로 업로드를 하는 api
+    @PostMapping("/api/blueprint/upload")
+    public ApiResponse<?> postBlueprintFileForInspection(//@AuthenticationPrincipal PrincipalDetails principal,
+                                                         @RequestParam("file") MultipartFile multipartFile) throws IOException {
+        return ApiResponse.onSuccess(blueprintS3UploadService.saveFileToInspection(multipartFile));
+    }
+
+    // 도면 상세 페이지 이미지 업로드
+    @PostMapping("/api/blueprint/detail-image/upload")
+    public ApiResponse<?> postBlueprintDetailImageForInspection(//@AuthenticationPrincipal PrincipalDetails details,
+                                                                @RequestParam("/file") MultipartFile multipartFile) throws IOException {
+        return ApiResponse.onSuccess(blueprintS3UploadService.saveFileToDetails(multipartFile));
+    }
+
+    // 도면 썸네일 업로드
+    // 썸네일에 대한 버킷은 아직 만들지 않음 -> 상세페이지 이미지랑 같이 저장할까 생각 중 (좋은 의견있으면 알려주세요)
+    @PostMapping("/api/blueprint/thumbnail/upload")
+    public ApiResponse<?> postBlueprintThumbnailForInspection(//@AuthenticationPrincipal PrincipalDetails details,
+                                                              @RequestParam("/file") MultipartFile multipartFile) throws IOException {
+        if (multipartFile.isEmpty()) throw new BaseException(ErrorCode.BLUEPRINT_FILE_NECESSARY);
+        return ApiResponse.onSuccess(blueprintS3UploadService.saveFileToDetails(multipartFile));
+    }
+
+}

--- a/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintUploadRequest.java
+++ b/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintUploadRequest.java
@@ -1,0 +1,15 @@
+package com.onetool.server.blueprint.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BlueprintUploadRequest(
+        String blueprintName,
+        Long categoryId,
+        Long standardPrice,
+        String blueprintImg,
+        String blueprintDetails,
+        String extension,
+        String program,
+        String creatorName
+) {}

--- a/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintUploadResponse.java
+++ b/server/src/main/java/com/onetool/server/blueprint/dto/BlueprintUploadResponse.java
@@ -1,0 +1,14 @@
+package com.onetool.server.blueprint.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BlueprintUploadResponse(
+    String fileUrl
+) {
+    public static BlueprintUploadResponse of(String fileUrl) {
+        return BlueprintUploadResponse.builder()
+                .fileUrl(fileUrl)
+                .build();
+    }
+}

--- a/server/src/main/java/com/onetool/server/blueprint/service/BlueprintS3UploadService.java
+++ b/server/src/main/java/com/onetool/server/blueprint/service/BlueprintS3UploadService.java
@@ -1,0 +1,80 @@
+package com.onetool.server.blueprint.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.onetool.server.global.exception.BaseException;
+import com.onetool.server.global.exception.codes.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class BlueprintS3UploadService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    //검수받을 도면 버킷
+    @Value("${cloud.aws.s3.bucket.inspection}")
+    private String inspectionBucket;
+
+    //검수 완료 후 판매 가능한 도면 버킷
+    @Value("${cloud.aws.s3.bucket.sales}")
+    private String salesBucket;
+
+    //도면 상세페이지 이미지 버킷
+    @Value("${cloud.aws.s3.bucket.details}")
+    private String detailsBucket;
+
+
+    // TODO : key(파일 명) 생성전략은 차차 생각해보겠음
+
+    public String saveFileToInspection(MultipartFile multipartFile) throws IOException {
+
+        if (multipartFile.isEmpty()) throw new BaseException(ErrorCode.BLUEPRINT_FILE_NECESSARY);
+        if (isContentTypeNotAllowed(multipartFile.getContentType())) throw new BaseException(ErrorCode.BLUEPRINT_FILE_EXTENSION_NOT_ALLOWED);
+
+        String originalFilename = multipartFile.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        log.info("type : {}", multipartFile.getContentType());
+        metadata.setContentType(multipartFile.getContentType());
+
+        amazonS3Client.putObject(inspectionBucket, originalFilename, multipartFile.getInputStream(), metadata);
+        return amazonS3Client.getUrl(inspectionBucket, originalFilename).toString();
+    }
+
+    private boolean isContentTypeNotAllowed(String contentType) {
+        return !contentType.equals("image/vnd.dwg");
+    }
+
+    public String saveFileToSales(MultipartFile multipartFile) throws IOException {
+        String originalFilename = multipartFile.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        amazonS3Client.putObject(salesBucket, originalFilename, multipartFile.getInputStream(), metadata);
+        return amazonS3Client.getUrl(salesBucket, originalFilename).toString();
+    }
+
+    public String saveFileToDetails(MultipartFile multipartFile) throws IOException {
+        String originalFilename = multipartFile.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        amazonS3Client.putObject(detailsBucket, originalFilename, multipartFile.getInputStream(), metadata);
+        return amazonS3Client.getUrl(detailsBucket, originalFilename).toString();
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/config/S3Config.java
+++ b/server/src/main/java/com/onetool/server/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.onetool.server.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+
+}

--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     private static final String[] AUTH_WHITELIST = {
-            "/users/**", "/login/**", "/blueprint/**"
+            "/users/**", "/login/**", "/blueprint/**", "/api/**"
     };
 
     @Bean

--- a/server/src/main/java/com/onetool/server/global/exception/WebErrorController.java
+++ b/server/src/main/java/com/onetool/server/global/exception/WebErrorController.java
@@ -4,7 +4,6 @@ import com.onetool.server.global.exception.codes.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.servlet.error.ErrorController;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +20,7 @@ public class WebErrorController implements ErrorController {
         if (status != null) {
             int statusCode = Integer.parseInt(status.toString());
             if (statusCode == HttpStatus.NOT_FOUND.value()) {
-                throw new BaseException(ErrorCode.IO_ERROR);
+                throw new BaseException(ErrorCode.URL_NON_EXIST);
             }
         }
         return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR.getCode(), ErrorCode.INTERNAL_SERVER_ERROR.getMessage(), null);

--- a/server/src/main/java/com/onetool/server/global/exception/codes/BaseCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/BaseCode.java
@@ -3,5 +3,5 @@ package com.onetool.server.global.exception.codes;
 import com.onetool.server.global.exception.codes.reason.Reason;
 
 public interface BaseCode {
-    public Reason.ReasonDto getReasonHttpStatus();
+    Reason.ReasonDto getReasonHttpStatus();
 }

--- a/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
@@ -9,59 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode implements BaseCode {
 
-    // 가장 일반적인 응답
-    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
-
-    /**
-     * ******************************* Global Error CodeList ***************************************
-     * HTTP Status Code
-     * 400 : Bad Request
-     * 401 : Unauthorized
-     * 403 : Forbidden
-     * 404 : Not Found
-     * 500 : Internal Server Error
-     * *********************************************************************************************
-     */
-    // 잘못된 서버 요청
-    BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "G001", "Bad Request Exception"),
-
-    // @RequestBody 데이터 미 존재
-    REQUEST_BODY_MISSING_ERROR(HttpStatus.BAD_REQUEST, "G002", "Required request body is missing"),
-
-    // 유효하지 않은 타입
-    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "G003", " Invalid Type Value"),
-
-    // Request Parameter 로 데이터가 전달되지 않을 경우
-    MISSING_REQUEST_PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "G004", "Missing Servlet RequestParameter Exception"),
-
-    // 입력/출력 값이 유효하지 않음
-    IO_ERROR(HttpStatus.BAD_REQUEST, "G005", "I/O Exception"),
-
-    // com.google.gson JSON 파싱 실패
-    JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "G006", "JsonParseException"),
-
-    // com.fasterxml.jackson.core Processing Error
-    JACKSON_PROCESS_ERROR(HttpStatus.BAD_REQUEST, "G007", "com.fasterxml.jackson.core Exception"),
-
-    // 권한이 없음
-    FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "G008", "Forbidden Exception"),
-
-    // 서버로 요청한 리소스가 존재하지 않음
-    NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "G009", "Not Found Exception"),
-
-    // NULL Point Exception 발생
-    NULL_POINT_ERROR(HttpStatus.NOT_FOUND, "G010", "Null Point Exception"),
-
-    // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
-    NOT_VALID_ERROR(HttpStatus.NOT_FOUND, "G011", "handle Validation Exception"),
-
-    // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
-    NOT_VALID_HEADER_ERROR(HttpStatus.NOT_FOUND, "G012", "Header에 데이터가 존재하지 않는 경우 "),
-
     // 4xx : client error
+
+    //url 에러
+    URL_NON_EXIST(HttpStatus.NOT_FOUND, "URL ERROR", "잘못된 경로입니다."),
 
     //사용자 에러
     NON_EXIST_USER(HttpStatus.NOT_FOUND, "MEMBER-0001", "존재하지 않는 회원입니다"),
@@ -76,6 +27,8 @@ public enum ErrorCode implements BaseCode {
 
     //도면 에러
     NO_BLUEPRINT_FOUND(HttpStatus.NOT_FOUND, "BLUEPRINT-0000", "도면이 존재하지 않습니다."),
+    BLUEPRINT_FILE_NECESSARY(HttpStatus.BAD_REQUEST, "BLUEPRINT-0001", "도면 파일을 업로드해주세요."),
+    BLUEPRINT_FILE_EXTENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BLUEPRINT-0002", "도면 파일 확장자가 올바르지 않습니다."),
 
     //장바구니 에러
     NO_ITEM_IN_CART(HttpStatus.NO_CONTENT, "CART-0000", "장바구니에 상품이 없습니다."),

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.onetool.server.global.exception.*;
 import com.onetool.server.global.exception.codes.ErrorCode;
 import com.onetool.server.global.exception.codes.reason.Reason;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.io.IOException;
@@ -35,6 +37,12 @@ public class ExceptionAdvice {
     public ResponseEntity<Object> validation(MethodArgumentNotValidException e) {
         String message = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
         ApiResponse<?> baseResponse = ApiResponse.onFailure(ErrorCode.BINDING_ERROR.getCode(), message, null);
+        return handleExceptionInternal(baseResponse);
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<Object> io(MultipartException e) {
+        ApiResponse<?> baseResponse = ApiResponse.onFailure(ErrorCode.BLUEPRINT_FILE_NECESSARY.getCode(), ErrorCode.BLUEPRINT_FILE_NECESSARY.getMessage(), null);
         return handleExceptionInternal(baseResponse);
     }
 
@@ -69,11 +77,11 @@ public class ExceptionAdvice {
      * @param e
      * @return
      */
-    @ExceptionHandler
-    public ResponseEntity<Object> exception(Exception e) {
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Object> exception(RuntimeException e) {
         log.error(e.getMessage());
-        ErrorCode errorCode = ErrorCode._INTERNAL_SERVER_ERROR;
-        ApiResponse<?> baseResponse = ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null);
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ApiResponse<?> baseResponse = ApiResponse.onFailure(errorCode.getCode(), e.getMessage(), null);
         return handleExceptionInternal(baseResponse);
     }
 
@@ -88,107 +96,6 @@ public class ExceptionAdvice {
         ApiResponse<?> baseResponse = ApiResponse.onFailure(errorReasonHttpStatus.getCode(), errorReasonHttpStatus.getMessage(), null);
         return handleExceptionInternal(baseResponse);
     }
-
-    /**
-     * [Exception] API 호출 시 'Header' 내에 데이터 값이 유효하지 않은 경우
-     *
-     * @param ex MissingRequestHeaderException
-     * @return ResponseEntity<ErrorResponse>
-     */
-    @ExceptionHandler(MissingRequestHeaderException.class)
-    protected ResponseEntity<Object> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
-        log.error("MissingRequestHeaderException", ex);
-
-        return handleExceptionInternal(ErrorCode.REQUEST_BODY_MISSING_ERROR);
-    }
-
-    /**
-     * [Exception] 클라이언트에서 Body로 '객체' 데이터가 넘어오지 않았을 경우
-     *
-     * @param ex HttpMessageNotReadableException
-     * @return ResponseEntity<ErrorResponse>
-     */
-    @ExceptionHandler
-    public ResponseEntity<Object> handleHttpMessageNotReadableException(
-            HttpMessageNotReadableException ex) {
-        log.info("HttpMessageNotReadableException", ex);
-        return handleExceptionInternal(ErrorCode.REQUEST_BODY_MISSING_ERROR);
-    }
-
-    /**
-     * [Exception] 클라이언트에서 request로 '파라미터로' 데이터가 넘어오지 않았을 경우
-     *
-     * @param ex MissingServletRequestParameterException
-     * @return ResponseEntity<ErrorResponse>
-     */
-    @ExceptionHandler(MissingServletRequestParameterException.class)
-    protected ResponseEntity<Object> handleMissingRequestHeaderExceptionException(
-            MissingServletRequestParameterException ex) {
-        log.error("handleMissingServletRequestParameterException", ex);
-        return handleExceptionInternal(ErrorCode.MISSING_REQUEST_PARAMETER_ERROR);
-    }
-
-
-    /**
-     * [Exception] 잘못된 서버 요청일 경우 발생한 경우
-     *
-     * @param e HttpClientErrorException
-     * @return ResponseEntity<ErrorResponse>
-     */
-    @ExceptionHandler(HttpClientErrorException.BadRequest.class)
-    protected ResponseEntity<Object> handleBadRequestException(HttpClientErrorException e) {
-        log.error("HttpClientErrorException.BadRequest", e);
-        return handleExceptionInternal(ErrorCode.BAD_REQUEST_ERROR);
-    }
-
-
-    /**
-     * [Exception] NULL 값이 발생한 경우
-     *
-     * @param e NullPointerException
-     * @return ResponseEntity<ErrorResponse>
-     */
-    @ExceptionHandler(NullPointerException.class)
-    protected ResponseEntity<Object> handleNullPointerException(NullPointerException e) {
-        log.error("handleNullPointerException", e);
-        return handleExceptionInternal(ErrorCode.NULL_POINT_ERROR);
-    }
-
-    /**
-     * Input / Output 내에서 발생한 경우
-     *
-     * @param ex IOException
-     * @return ResponseEntity<ErrorResponse>
-     */
-    @ExceptionHandler(IOException.class)
-    protected ResponseEntity<Object> handleIOException(IOException ex) {
-        log.error("handleIOException", ex);
-        return handleExceptionInternal(ErrorCode.IO_ERROR);
-    }
-
-    /**
-     * com.fasterxml.jackson.core 내에 Exception 발생하는 경우
-     *
-     * @param ex JsonProcessingException
-     * @return ResponseEntity<ErrorResponse>
-     */
-    @ExceptionHandler(JsonProcessingException.class)
-    protected ResponseEntity<Object> handleJsonProcessingException(JsonProcessingException ex) {
-        log.error("handleJsonProcessingException", ex);
-        return handleExceptionInternal(ErrorCode.REQUEST_BODY_MISSING_ERROR);
-    }
-
-    /**
-     * [Exception] 잘못된 주소로 요청 한 경우
-     *
-     * @param e NoHandlerFoundException
-     * @return ResponseEntity<ErrorResponse>
-     */
-//    @ExceptionHandler(NoHandlerFoundException.class)
-//    protected ResponseEntity<Object> handleNoHandlerFoundExceptionException(NoHandlerFoundException e) {
-//        log.error("handleNoHandlerFoundExceptionException", e);
-//        return handleExceptionInternal(ErrorCode.NOT_FOUND_ERROR);
-//    }
 
     private ResponseEntity<Object> handleExceptionInternal(ApiResponse<?> response) {
         return new ResponseEntity<>(response, HttpStatus.OK);


### PR DESCRIPTION
# 🎟️ 티켓 번호
TIC-100

## 🔎 작업 내용
### feat 
- 도면 관련 파일 S3 업로드 기능 추가 (단일 파일)


### chore
- 도면 업로드에 대한 예외 추가
- S3 Config 추가
- 파일 없이 업로드 요청 시 MultipartException을 ExceptionHandler에서 처리
- 도면 업로드 관련 DTO 생성
- SecurityConfig에서 도면 업로드 api는 유저 인증 거치지 않게 임시로 설정
- URL 오류 시 URL_NON_EXIST 예외 처리


### build
- jdbc dependency 삭제
- aws 및 http 관련 dependency 추가


<br/>

## 🔧 앞으로의 과제
- 도면 업로드 페이지 컴포넌트를 정확히 안 후 api 다시 설계 예정. 지금은 도면, 도면 상세 이미지, 썸네일 등 각기 다른 api로 설정함
- 다중 파일 업로드 구현 예정
- 파일 확장자 제한 로직 추가
- 파일 명 생성 전략 고민 필요
<br/>
