### PR TITLE
fix(redis): RedisTemplate 빈 충돌 문제

### DIFF
--- a/server/src/main/java/com/onetool/server/global/redis/service/MailRedisService.java
+++ b/server/src/main/java/com/onetool/server/global/redis/service/MailRedisService.java
@@ -2,6 +2,7 @@ package com.onetool.server.global.redis.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -15,10 +16,15 @@ import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class MailRedisService {
 
     private final RedisTemplate<String, Object> mailRedisTemplate;
+
+    public MailRedisService(
+            @Qualifier("mailRedisTemplate")
+            RedisTemplate<String, Object> mailRedisTemplate) {
+        this.mailRedisTemplate = mailRedisTemplate;
+    }
 
     public void setValues(String key, String data) {
         ValueOperations<String, Object> values = mailRedisTemplate.opsForValue();

--- a/server/src/main/java/com/onetool/server/global/redis/service/TokenRedisService.java
+++ b/server/src/main/java/com/onetool/server/global/redis/service/TokenRedisService.java
@@ -3,6 +3,7 @@ package com.onetool.server.global.redis.service;
 import com.onetool.server.member.dto.MemberLoginResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -13,10 +14,15 @@ import java.time.Duration;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class TokenRedisService {
 
     private final RedisTemplate<String, Object> tokenRedisTemplate;
+
+    public TokenRedisService(
+            @Qualifier("tokenRedisTemplate")
+            RedisTemplate<String, Object> tokenRedisTemplate) {
+        this.tokenRedisTemplate = tokenRedisTemplate;
+    }
 
     public void setValuesWithTimeout(String s, String refreshToken, Long refreshTokenExpirationMillis) {
         ValueOperations<String, Object> values = tokenRedisTemplate.opsForValue();

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -16,4 +16,4 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 spring.config.import=optional:application-api.properties
 
-logging.level.org.springframework.security=trace
+logging.level.org.springframework.security=info


### PR DESCRIPTION
## 🔎 작업 내용
- Mail인증 용 RedisTemplate와 JwtRefreshToken 용 RedisTemplate가 Service에서 정확하게 지정되지 않음.
- `@qualifier`를 통해 각 RedisTemplate을 지정하여 해결

<br/>

## 🔧 앞으로의 과제

- 개발용 더미데이터 지정
- 개발용 서버 생성 및 CI/CD 구축

  <br/>

## ➕ 이슈 링크

없음

<br/>
