### PR TITLE
[#83] test(member):회원 삭제 로직 오류 수정 

### DIFF
--- a/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
+++ b/server/src/test/java/com/onetool/server/member/MemberServiceTest.java
@@ -69,29 +69,29 @@ public class MemberServiceTest {
                 "isNative", true
         );
 
-        // when
-        final ExtractableResponse<Response> signupResponse = RestAssured.given().log().all()
+        // 회원가입
+        RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)
                 .when().post("/users/signup")
-                .then().log().all()
-                .extract();
+                .then().log().all();
 
-        final long userId = Long.parseLong(signupResponse.path("result.id").toString());
-
+        // 로그인 후 토큰 가져오기
         String token = loginAndReturnToken();
 
+        // when
         final ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + token)
-                .when().delete("/users/" + userId)
+                .when().delete("/users")
                 .then().log().all()
                 .extract();
 
         // then
         final JsonPath result = deleteResponse.jsonPath();
-        String message = result.getString("message");
+        String message = result.getString("result");
         assertThat(message).isEqualTo("회원 탈퇴가 완료되었습니다.");
     }
+
 
     @Test
     @DisplayName("로그인 후 회원 정보 조회 성공 테스트")


### PR DESCRIPTION
## 🔎 작업 내용

-  blueprintController에 맞춰 `/users`로 api 변경
- "message"가 아니라 "result"를 비교하도록 수정

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

[likelion-onetool #83 ](https://github.com/likelion-onetool/backend/issues/83)

<br/>
