### PR TITLE
fix(redis): RedisConfig 비밀번호 설정

### DIFF
--- a/server/src/main/java/com/onetool/server/global/redis/config/RedisConfig.java
+++ b/server/src/main/java/com/onetool/server/global/redis/config/RedisConfig.java
@@ -52,6 +52,7 @@ public class RedisConfig {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
         config.setHostName(redisProperties.getHost());
         config.setPort(redisProperties.getPort());
+        config.setPassword(redisProperties.getPassword());
         config.setDatabase(index);
         return new LettuceConnectionFactory(config);
     }


### PR DESCRIPTION
## 🔎 작업 내용

- Docker Redis 컨테이너에 비밀번호를 설정했지만, Spring RedisConfig에 비밀번호가 설정되어 있지않아 발생한 문제

<br/>

## 🔧 앞으로의 과제
- [x] redis 컨테이너와 Spring application 컨테이너 연동 확인
- [ ] ALB 대상그룹 health check 확인
- [ ] HTTPS 최종 연결

  <br/>

## ➕ 이슈 링크

<!-- [레포 이름 #이슈번호](이슈 주소) -->
#75 
<br/>
