### PR TITLE
fix(security): anyRequest 후 requestMatchers 설정 문제

### DIFF
--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -80,8 +80,8 @@ public class SecurityConfig {
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(AUTH_WHITELIST).permitAll()
-                        .anyRequest().authenticated()
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                        .anyRequest().authenticated()
                 )
                 .oauth2Login(auth -> {
                     auth.successHandler(oAuth2LoginSuccessHandler)


### PR DESCRIPTION
## 🔎 작업 내용
- Spriong Securty 필터체인에서  authorizeHttpRequests 설정 중 anyRequest 후에 requestMatchers가 있어 에러 발생
```java
.authorizeHttpRequests(authorize -> authorize
    .requestMatchers(AUTH_WHITELIST).permitAll()
    .anyRequest().authenticated()
    .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
)
```
- requestMatchers 다음에 anyRequest가 오도록 수정

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크
#93 
<!-- [레포 이름 #이슈번호](이슈 주소) -->

<br/>
