### PR TITLE
fix: refreshToken 전달 방식 쿠기로 변경

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/dto/MemberLoginResponse.java
+++ b/server/src/main/java/com/onetool/server/api/member/dto/MemberLoginResponse.java
@@ -3,13 +3,11 @@ package com.onetool.server.api.member.dto;
 import lombok.Builder;
 
 public record MemberLoginResponse(
-        String accessToken,
-        String refreshToken
+        String accessToken
 ) {
 
     @Builder
-    public MemberLoginResponse(String accessToken, String refreshToken) {
+    public MemberLoginResponse(String accessToken) {
         this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
     }
 }

--- a/server/src/main/java/com/onetool/server/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -46,7 +46,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 Map<String, String> tokens = jwtUtil.createTokens(memberAuthContext);
                 MemberLoginResponse tokenResponse = MemberLoginResponse.builder()
                                 .accessToken("Bearer " + tokens.get("accessToken"))
-                                .refreshToken(tokens.get("refreshToken"))
                                 .build();
                 String result = objectMapper.writeValueAsString(tokenResponse);
 
@@ -70,7 +69,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         Map<String, String> tokens = jwtUtil.createTokens(memberAuthContext);
         MemberLoginResponse tokenResponse = MemberLoginResponse.builder()
                 .accessToken("Bearer " + tokens.get("accessToken"))
-                .refreshToken(tokens.get("refreshToken"))
                 .build();
         String result = objectMapper.writeValueAsString(tokenResponse);
 


### PR DESCRIPTION

## 🔎 작업 내용
- 기존 Payload에 accessToken과 refreshToken을 같이 보낼 경우, refreshToken에 대한 XSF 공격에 취약합니다.
- `HttpOnly` 옵션을 통한 `쿠키`로 전달할 수 있도록 설정했어요
- 쿠키 만료 기간을 `7일`로 설정

<br/>

## 🔧 앞으로의 과제

  <br/>

## ➕ 이슈 링크

<!-- [레포 이름 #이슈번호](이슈 주소) -->
#98 

<br/>
