### PR TITLE
fix(search): 검색어 URL 디코딩 추가

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/controller/SearchController.java
@@ -4,6 +4,7 @@ import com.onetool.server.api.blueprint.dto.SearchResponse;
 import com.onetool.server.api.blueprint.service.BlueprintService;
 import com.onetool.server.api.category.FirstCategoryType;
 import com.onetool.server.global.exception.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -12,6 +13,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
 @RestController
 public class SearchController {
 
@@ -26,8 +31,9 @@ public class SearchController {
             @RequestParam("s")String keyword,
             @PageableDefault(size = 5, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
     ) {
-
-        Page<SearchResponse> response = blueprintService.searchNameAndCreatorWithKeyword(keyword, pageable);
+        String decodedKeyword = URLDecoder.decode(keyword, StandardCharsets.UTF_8);
+        log.info("Decoded keyword: {}", decodedKeyword);
+        Page<SearchResponse> response = blueprintService.searchNameAndCreatorWithKeyword(decodedKeyword, pageable);
         return ApiResponse.onSuccess(response);
     }
 


### PR DESCRIPTION
## 🔎 작업 내용
프론트 단에서 전송한 검색어가 UTF-8로 인코딩되어 전송됨. 따라서, 서버 측에서 keyword를 받고 이를 UTF-8로 디코딩하여 사용.

검색어로 검색할 때 예를들어 "평면"을 검색하면
https://test.onetool.co.kr/blueprint?s=%ED%8F%89%EB%A9%B4&page=0&size=8 이런식으로 전송되어 백엔드에서 디코딩이 필요함.

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

<!-- [레포 이름 #이슈번호](이슈 주소) -->
#98 
<br/>
