### PR TITLE
fix(blueprint): 검수여부에 따른 전체 도면 검색 기능 수정 

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintInspectionController.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintInspectionController.java
@@ -4,6 +4,9 @@ import com.onetool.server.api.blueprint.dto.BlueprintResponse;
 import com.onetool.server.api.blueprint.service.BlueprintInspectionService;
 import com.onetool.server.global.exception.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,8 +19,9 @@ public class BlueprintInspectionController {
     private final BlueprintInspectionService blueprintInspectionService;
 
     @GetMapping("/inspection")
-    public ApiResponse<List<BlueprintResponse>> getNotPassedBlueprints() {
-        List<BlueprintResponse> responses = blueprintInspectionService.findAllNotPassedBlueprints();
+    public ApiResponse<List<BlueprintResponse>> getNotPassedBlueprints(
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        List<BlueprintResponse> responses = blueprintInspectionService.findAllNotPassedBlueprints(pageable);
         return ApiResponse.onSuccess(responses);
     }
 

--- a/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
@@ -31,5 +31,5 @@ public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
     Long countAllBlueprint();
 
     @Query(value = "SELECT b FROM Blueprint b WHERE b.inspectionStatus = :status")
-    List<Blueprint> findByInspectionStatus(@Param("status") InspectionStatus status);
+    Page<Blueprint> findByInspectionStatus(@Param("status") InspectionStatus status, Pageable pageable);
 }

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintInspectionService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintInspectionService.java
@@ -6,6 +6,8 @@ import com.onetool.server.api.blueprint.repository.BlueprintRepository;
 import com.onetool.server.api.blueprint.InspectionStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +22,8 @@ public class BlueprintInspectionService {
     private final BlueprintRepository blueprintRepository;
 
     @Transactional
-    public List<BlueprintResponse> findAllNotPassedBlueprints(){
-        List<Blueprint> blueprints = blueprintRepository.findByInspectionStatus(InspectionStatus.NONE);
+    public List<BlueprintResponse> findAllNotPassedBlueprints(Pageable pageable){
+        Page<Blueprint> blueprints = blueprintRepository.findByInspectionStatus(InspectionStatus.NONE, pageable);
 
         return blueprints.stream()
                 .map(BlueprintResponse::from)

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintRefreshService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintRefreshService.java
@@ -6,6 +6,8 @@ import com.onetool.server.api.blueprint.InspectionStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -21,13 +23,12 @@ public class BlueprintRefreshService {
     @Scheduled(cron = "0 0 0 * * *")  // 매일 자정 새로고침
     public void refreshApprovedBlueprints() {
         log.info("Refreshing approved blueprints at midnight...");
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<Blueprint> approvedBlueprints = blueprintRepository.findByInspectionStatus(InspectionStatus.PASSED, pageable);
 
-        List<Blueprint> approvedBlueprints = blueprintRepository.findByInspectionStatus(InspectionStatus.PASSED);
-
-        refreshBlueprints(approvedBlueprints);
+        refreshBlueprints(approvedBlueprints.getContent());
     }
 
-    @Transactional
     private void refreshBlueprints(List<Blueprint> blueprints) {
         for (Blueprint blueprint : blueprints) {
             log.info("Refreshing blueprint: {}", blueprint.getId());

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
@@ -98,7 +98,7 @@ public class BlueprintService {
     }
 
     public Page<SearchResponse> findAll(Pageable pageable) {
-        Page<Blueprint> result = blueprintRepository.findAll(pageable);
+        Page<Blueprint> result = blueprintRepository.findByInspectionStatus(InspectionStatus.PASSED, pageable);
         List<SearchResponse> list = result.getContent().stream()
                 .map(SearchResponse::from)
                 .collect(Collectors.toList());

--- a/server/src/test/java/com/onetool/server/blueprint/BlueprintInspectionTest.java
+++ b/server/src/test/java/com/onetool/server/blueprint/BlueprintInspectionTest.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,14 +33,15 @@ public class BlueprintInspectionTest {
     @DisplayName("검증이 필요한 도면들을 불러오고, 그 중 한 개를 승인합니다.")
     void get_and_approve_bluprint_test() {
         // given
-        log.info("{}", blueprintInspectionService.findAllNotPassedBlueprints().size());
+        PageRequest pageable = PageRequest.of(0, 10);
+        log.info("{}", blueprintInspectionService.findAllNotPassedBlueprints(pageable).size());
 
         // when
         blueprintInspectionService.approveBlueprint(1L);
 
         // then
         assertThat(
-                blueprintInspectionService.findAllNotPassedBlueprints().size()
+                blueprintInspectionService.findAllNotPassedBlueprints(pageable).size()
         ).isEqualTo(5);
     }
 

--- a/server/src/test/java/com/onetool/server/blueprint/BlueprintInspectionTest.java
+++ b/server/src/test/java/com/onetool/server/blueprint/BlueprintInspectionTest.java
@@ -42,7 +42,7 @@ public class BlueprintInspectionTest {
         // then
         assertThat(
                 blueprintInspectionService.findAllNotPassedBlueprints(pageable).size()
-        ).isEqualTo(5);
+        ).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## 🔎 작업 내용
- `findByInspectionStatus`는 **List<>** 대신 `Page<>`를 반환하도록 수정
- 기존 blueprint refresh 로직에서 List<>를 사용한다. 위 메서드를 통해 반환받은 Page를 `Page<>.getContent`를 통해 List 변환하여 사용하도록 수정

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

<!-- [레포 이름 #이슈번호](이슈 주소) -->
#96 
<br/>
