### PR TITLE
🔨fix: Google OAuth2 버그 수정

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/enums/SocialType.java
+++ b/server/src/main/java/com/onetool/server/api/member/enums/SocialType.java
@@ -1,5 +1,18 @@
 package com.onetool.server.api.member.enums;
 
 public enum SocialType {
-    NAVER, KAKAO, GOOGLE
+    NAVER("naver"),
+    KAKAO("kakao"),
+    GOOGLE("google"),
+    OTHER("other");
+
+    private final String value;
+
+    SocialType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/server/src/main/java/com/onetool/server/global/auth/login/OAuthAttributes.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/OAuthAttributes.java
@@ -14,8 +14,8 @@ import java.util.UUID;
 @Getter
 public class OAuthAttributes {
 
-    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
-    private OAuth2UserInfo oAuth2UserInfo;
+    private final String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private final OAuth2UserInfo oAuth2UserInfo;
 
     @Builder
     public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oAuth2UserInfo) {
@@ -28,7 +28,7 @@ public class OAuthAttributes {
         return ofGoogle(userNameAttributeName, attributes);
     }
 
-    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
         return OAuthAttributes.builder()
                 .nameAttributeKey(userNameAttributeName)
                 .oAuth2UserInfo(new GoogleOAuth2UserInfo(attributes))
@@ -41,7 +41,7 @@ public class OAuthAttributes {
                 .socialId(oauth2UserInfo.getId())
                 .email(UUID.randomUUID() + "@socialUser.com")
                 .name(oauth2UserInfo.getName())
-                .role(UserRole.ROLE_GUEST)
+                .role(UserRole.ROLE_USER)
                 .platformType("SSO")
                 .build();
     }

--- a/server/src/main/java/com/onetool/server/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -62,6 +62,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private void loginSuccess(HttpServletResponse response, MemberAuthContext context) throws  IOException {
         MemberAuthContext memberAuthContext = MemberAuthContext.builder()
+                .id(context.getId())
                 .email(context.getEmail())
                 .role(context.getRole())
                 .build();

--- a/server/src/main/java/com/onetool/server/global/auth/login/service/CustomOAuth2UserService.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/service/CustomOAuth2UserService.java
@@ -43,6 +43,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         Member createdMember = getMember(extractAttributes, socialType);
         MemberAuthContext context = MemberAuthContext.builder()
+                .id(createdMember.getId())
                 .email(createdMember.getEmail())
                 .name(createdMember.getName())
                 .role(createdMember.getRole().name())
@@ -53,7 +54,15 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     private SocialType getSocialType(String registrationId) {
-        return SocialType.GOOGLE;
+        if(registrationId.equals(SocialType.GOOGLE.name())){
+            return SocialType.GOOGLE;
+        } else if(registrationId.equals(SocialType.KAKAO.name())){
+            return SocialType.KAKAO;
+        } else if(registrationId.equals(SocialType.NAVER.name())){
+            return SocialType.NAVER;
+        } else {
+            return SocialType.OTHER;
+        }
     }
 
     private Member getMember(OAuthAttributes attributes, SocialType socialType) {

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -16,4 +16,4 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 spring.config.import=optional:application-api.properties
 
-logging.level.org.springframework.security=info
+#logging.level.org.springframework.security=info


### PR DESCRIPTION
## #️⃣ 이슈

- close #110 

## 🔎 작업 내용
Google OAuth2가 작동하지 않던 문제는 다음과 같았습니다.

1. 과거 사용 중이던 OAuth2 API가 삭제되어 있던 점
2. 리소스 서버로 부터 받아온 정보 중 ID를 추가하지 않아 JWT 토큰이 제대로 생성되지 않던 점
3. 리소스 서버로부터의 정보 중 scope가 설정되어 있지 않아 형변환 오류가 발생했던 점

이 중 1, 2번의 경우 단순히 ID 값 주입 및 submodule 업데이트로 해결했습니다.

3번의 경우, 리소스 서버로 부터 받아오는 정보에 따라 형변환되는 객체가 달라짐에 따라 발생했습니다.
```java
@Override
public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
    log.info("OAuth2 Login 성공");
    try {
        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
        MemberAuthContext member = principalDetails.getContext();
// 이하 생략
```

_현재 scope가 설정되어 있지 않은 경우,_ 
제가 만든 `PrincipalDetail`로 Case되지 않고 `DefaultOidcUser`로 Case 돼요.
그 이유는 PrincipalDetail과 DefaultOidcUser는 모두 **OAuth2User의 구현체**이기 때문이에요.

둘 중 큰 차이는 DefaultOidcUser는 openId를 포함하기 때문에 Scope 설정을 통해 PrincipalDetail을 사용하도록 수정했습니다.

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

| birth\_date | is\_deleted | is\_native | service\_accept | social\_type | user\_registered\_at | created\_at | id | updated\_at | name | phone\_num | email | field | password | platform\_type | social\_id | user\_role |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| null | false | false | false | 3 | null | 2025-01-02 14:50:26.637307 | 1 | 2025-01-02 14:50:26.637348 | 성원 | null | 31b5d6d8-9498-46d9-babc-62aadd41f46e@socialUser.com | null | null | SSO | 100174848896187249417 | ROLE\_USER |

현재 로그인 시, 위와 같은 형태로 저장됩니다. SSO를 통해 받아올 수 없는 정보는 어떤 식으로 처리할지에 대해 추후 정해봐야할 것 같아요.

## 🧲 참고 자료 및 공유 사항
[DefaultOAuth2User 형변환](https://velog.io/@dlsrjsdl6505/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EB%A6%AC%ED%8C%A9%ED%84%B0%EB%A7%81-SOLID%EC%9B%90%EC%B9%99)

