### PR TITLE
feat: blueprint categoryId 별로 정렬 기능 추가

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintController.java
@@ -59,27 +59,16 @@ public class BlueprintController {
         return ApiResponse.onSuccess("상품이 정상적으로 삭제 되었습니다.");
     }
 
-    @GetMapping("/sort")
+    @GetMapping({"/sort", "{categoryId}/sort"})
     public ApiResponse<List<BlueprintResponse>> sortBlueprints(
+            @PathVariable(value = "categoryId", required = false) Long categoryId,
             @RequestParam String sortBy,
-            @RequestParam(required = false) String sortOrder,
+            @RequestParam(required = false, defaultValue = "asc") String sortOrder,
             Pageable pageable
     ) {
-
-        BlueprintSortRequest blueprintSortRequest = new BlueprintSortRequest(null, sortBy, sortOrder);
-        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprintsByCategory(blueprintSortRequest, pageable);
-        return ApiResponse.onSuccess(sortedBlueprints);
+        BlueprintSortRequest request = new BlueprintSortRequest(categoryId, sortBy, sortOrder);
+        List<BlueprintResponse> sortedItems = blueprintService.sortBlueprintsByCategory(request, pageable);
+        return ApiResponse.onSuccess(sortedItems);
     }
 
-    @GetMapping("/{categoryId}/sort")
-    public ApiResponse<List<BlueprintResponse>> sortBlueprints(
-            @PathVariable long categoryId,
-            @RequestParam String sortBy,
-            @RequestParam(required = false) String sortOrder,
-            Pageable pageable
-    ) {
-        BlueprintSortRequest blueprintSortRequest = new BlueprintSortRequest(categoryId, sortBy, sortOrder);
-        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprintsByCategory(blueprintSortRequest, pageable);
-        return ApiResponse.onSuccess(sortedBlueprints);
-    }
 }

--- a/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintController.java
@@ -1,6 +1,8 @@
 package com.onetool.server.api.blueprint.controller;
 import com.onetool.server.api.blueprint.dto.BlueprintRequest;
 import com.onetool.server.api.blueprint.dto.BlueprintResponse;
+import com.onetool.server.api.blueprint.dto.BlueprintSortRequest;
+import org.springframework.data.domain.Pageable;
 import com.onetool.server.api.blueprint.service.BlueprintService;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
@@ -58,8 +60,26 @@ public class BlueprintController {
     }
 
     @GetMapping("/sort")
-    public ApiResponse<List<BlueprintResponse>> sortBlueprints(@RequestParam String sortBy) {
-        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprints(sortBy);
+    public ApiResponse<List<BlueprintResponse>> sortBlueprints(
+            @RequestParam String sortBy,
+            @RequestParam(required = false) String sortOrder,
+            Pageable pageable
+    ) {
+
+        BlueprintSortRequest blueprintSortRequest = new BlueprintSortRequest(null, sortBy, sortOrder);
+        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprintsByCategory(blueprintSortRequest, pageable);
+        return ApiResponse.onSuccess(sortedBlueprints);
+    }
+
+    @GetMapping("/{categoryId}/sort")
+    public ApiResponse<List<BlueprintResponse>> sortBlueprints(
+            @PathVariable long categoryId,
+            @RequestParam String sortBy,
+            @RequestParam(required = false) String sortOrder,
+            Pageable pageable
+    ) {
+        BlueprintSortRequest blueprintSortRequest = new BlueprintSortRequest(categoryId, sortBy, sortOrder);
+        List<BlueprintResponse> sortedBlueprints = blueprintService.sortBlueprintsByCategory(blueprintSortRequest, pageable);
         return ApiResponse.onSuccess(sortedBlueprints);
     }
 }

--- a/server/src/main/java/com/onetool/server/api/blueprint/dto/BlueprintSortRequest.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/dto/BlueprintSortRequest.java
@@ -1,0 +1,7 @@
+package com.onetool.server.api.blueprint.dto;
+
+public record BlueprintSortRequest(
+        Long categoryId,
+        String sortBy,
+        String sortOrder
+) {}

--- a/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
@@ -9,8 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
 

--- a/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
@@ -32,4 +32,11 @@ public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
 
     @Query(value = "SELECT b FROM Blueprint b WHERE b.inspectionStatus = :status AND b.isDeleted = false")
     Page<Blueprint> findByInspectionStatus(@Param("status") InspectionStatus status, Pageable pageable);
+
+    @Query("SELECT b FROM Blueprint b WHERE b.categoryId = :categoryId AND b.inspectionStatus = :inspectionStatus")
+    Page<Blueprint> findByCategoryIdAndStatus(
+            @Param("categoryId")   Long categoryId,
+            @Param("inspectionStatus") InspectionStatus inspectionStatus,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #98 

## 🔎 작업 내용
### feat: blueprint categoryId 별로 정렬 기능 추가

기존에 전체 도면에서만 sort가 되던 것을 categoryId별로 sort가 가능하도록 api를 추가했습니다. 
세부 추가사항은 아래와 같습니다! 

- blueprint categoryId별로 정렬이 가능하도록 GET 요청 추가: /blueprint/{categoryId}/sort
- 전체의 경우 GET : /blueprint/sort
-  PRICE, CREATED_AT, EXTENSION 에 대한 정렬 가능
- sortOrder 파라미터 추가 (오름차순: asc, 내림차순: desc)
- sortOrder가 null일 경우 기본값은 오름차순(asc)으로 처리
- 가격 정렬 시  salePrice가 유효할 경우엔 salePrice, 아닌 경우 standardPrice로 비교하여 정렬

- BlueprintServiceMockTest에 정렬에 대한 test 추가

<img width="596" alt="image" src="https://github.com/user-attachments/assets/4665a471-dc26-405d-adf0-0b2ea13eeda0" />

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
- category name 을 api 경로로 둘까 생각했었습니다. 그러면 수정해야할 부분이 많아지는 것 같아, 기존 blueprint에 있는 정보인 categoryId별로 정렬이 가능하도록 구현했습니다.  이름으로 두는게 더 나을까요?
그외 코드에 불필요한 부분이 있다면 말해주세요!


## 🧲 참고 자료 및 공유 사항
[Spring Pageable](https://velog.io/@soluinoon/Spring-Pageable)
[Spring Data JPA를 활용한 데이터 정렬 구현(JPA method & Pageable, Page)](https://velog.io/@kimdy0915/Spring-Data-JPA%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%A0%95%EB%A0%AC-%EA%B5%AC%ED%98%84JPA-method-Pageable-Page)
[Spring JPA Pageable 처리 - sort 및 Page 처리(totalElements) - 티스토리](https://juntcom.tistory.com/219)


