### PR TITLE
refactor: BlueprintSearchService에 읽기 전용 트랜잭션 부여

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintSearchService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintSearchService.java
@@ -13,12 +13,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import com.onetool.server.global.exception.BlueprintNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 public class BlueprintSearchService {
     private final BlueprintRepository blueprintRepository;
 


### PR DESCRIPTION
## #️⃣ 이슈

- close #113 

## 🔎 작업 내용

- BlueprintSearchService에 `@Transactional(readOnly=true)` 부여

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

BlueprintSearch 쿼리들은 조회만을 수행한다. @Transactional(readOnly = true)를 사용하면 아래의 장점이 있다.
## 장점
### 1. 데이터 일관성과 무결성 보장
### 2. 가독성 향상 : 개발자에게 읽기만 수행한다는 것을 표시
### 3. 성능 최적화

영속성 컨텍스트가 Entity 조회 시, 초기 상태의 Snapshot으로 저장한다. 트랜잭션 commit 시, Snapshot과 Entity 상태를 비교하여 변경된 내용에 대한 update Query를 생성해 쓰기 지연 저장소에 저장한다. 일괄적으로 쓰기 지연 저장소의 query들을 flush()하고, 트랜잭션을 commit()하여 entity의 수정이 이루어진다. 이를 `Dirty Checking`라고 한다.
readOnly =true 시, JPA의 세션 플러시 모드를 MANUAL로 수정한다. 이는 사용자가 수동으로 FLUSH 해야만 변경사항이 Entity에 반영되도록한다. 따라서, Snapshot을 생성하지 않아 **메모리 절약 가능하다.**

쉽게 말해 readOnly로 트랜잭션 실행 시, 해당 트랜잭션 영역에 대한 쓰기 작업이 비활성화 되기 때문에 무결성을 보장할 수 있다. 이와 관련하여 더 조사를 하면서 인상적인 사실을 알 수 있었다.

## 읽기 작업 시 @Transactional(readOnly=true)을 사용해야하는 이유
> [!TIP]
>  `OSIV(Open Session In View)` : 영속성 컨텍스트를 View Layer까지 유지하는 속성으로, 클라이언트의 요청 시점부터 영속성 컨텍스트를 생성하여 Filter / Interceptor - Controller에서 영속성 컨텍스트가 생성되어 View Layer까지 유지되어 **Layzy Loading**이 가능하도록 한다. (기본값 : true) 
단점 : API 호출이 많아질 경우 커넥션 부족으로 시스템 장애가 발생할 수 있음

> [!IMPORTANT]
>  OSIV가 꺼지게 되면 **영속성  컨텍스트에서 관리되지 않기 때문**에 Lazy Loading이 불가능하다. 이런 OSIV가 꺼진 상황에서 `@Transactional(readOnly = true)`를 통해 영속성에서 관리되기 때문에 OSIV의 상관없이 Lazy Loading을 보장 받을 수 있다.

쉽게 정리하면 영속성 컨텍스트에서 관리하도록하는 Spring 내부 OSIV이 꺼진 경우에도 영속성 컨텍스트에서 관리되도록 @Transactional(readOnly=true)를 설정하는 것이다.

## 🧲 참고 자료 및 공유 사항
[@Transactional(readOnly=true)을 사용하는 이유](https://hungseong.tistory.com/74)
[@Transactional(readOnly=true)을 왜 붙여야 하는가](https://velog.io/@uiurihappy/Spring-boot-TransactionalreadOnly-true%EB%8A%94-%EC%99%9C-%EB%B6%99%EC%97%AC%EC%95%BC-%ED%95%A0%EA%B9%8C)
[JPA의 OSIV 전략](https://hstory0208.tistory.com/entry/SpringJPA-OSIV-%EC%A0%84%EB%9E%B5%EC%9D%B4%EB%9E%80-%EC%96%B8%EC%A0%9C-%EC%82%AC%EC%9A%A9%ED%95%B4%EC%95%BC-%ED%95%A0%EA%B9%8C)

