### PR TITLE
fix: 로그인, RefreshToken 재발급 토큰 전달 방식 수정

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/api/member/controller/MemberController.java
@@ -32,17 +32,14 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ApiResponse<MemberLoginResponse> login(
+    public ApiResponse<String> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletResponse servletResponse
     ) {
         Map<String, String> tokens = memberService.login(request);
-        MemberLoginResponse response = MemberLoginResponse.builder()
-                .accessToken("Bearer " + tokens.get("accessToken"))
-                .build();
         ResponseCookie refreshTokenCookie = createRefreshTokenCookie(tokens.get("refreshToken"));
         servletResponse.setHeader("Set-Cookie", refreshTokenCookie.toString());
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(tokens.get("accessToken"));
     }
 
     @PostMapping("/signup")

--- a/server/src/main/java/com/onetool/server/global/redis/controller/TokenController.java
+++ b/server/src/main/java/com/onetool/server/global/redis/controller/TokenController.java
@@ -42,8 +42,7 @@ public class TokenController {
             return ResponseEntity
                     .status(HttpStatus.OK)
                     .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.get("accessToken"))
-                    .build();
+                    .body(tokens.get("accessToken"));
         } else {
             ResponseCookie responseCookie = ResponseCookie.from("refreshToken", "")
                     .maxAge(0)


### PR DESCRIPTION
- accessToken을 Body에 전송

## #️⃣ 이슈

- close #119 

## 🔎 작업 내용
1. 프론트엔드 팀의 요청에 따라 AccessToken 전달 방식을 변경
    - 기존 Authorization 헤더 대신 Body에 담아 전송
2. API 명세서 수정 (23번, 46번)

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

## 🧲 참고 자료 및 공유 사항


