### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintController.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/controller/BlueprintController.java
@@ -2,6 +2,7 @@ package com.onetool.server.api.blueprint.controller;
 import com.onetool.server.api.blueprint.dto.BlueprintRequest;
 import com.onetool.server.api.blueprint.dto.BlueprintResponse;
 import com.onetool.server.api.blueprint.dto.BlueprintSortRequest;
+import com.onetool.server.global.exception.codes.ErrorCode;
 import org.springframework.data.domain.Pageable;
 import com.onetool.server.api.blueprint.service.BlueprintService;
 import com.onetool.server.global.auth.login.PrincipalDetails;
@@ -24,7 +25,7 @@ public class BlueprintController {
     public ApiResponse<String> createBlueprint(@RequestBody BlueprintRequest blueprintRequest,
                                                @AuthenticationPrincipal PrincipalDetails principalDetails) {
         if(principalDetails == null) {
-            throw new MemberNotFoundException();
+            throw new MemberNotFoundException(ErrorCode.NON_EXIST_USER);
         }
 
         blueprintService.createBlueprint(blueprintRequest);
@@ -35,7 +36,7 @@ public class BlueprintController {
     public ApiResponse<String> updateBlueprint(@RequestBody BlueprintResponse blueprintResponse,
                                                @AuthenticationPrincipal PrincipalDetails principalDetails) {
         if(principalDetails == null) {
-            throw new MemberNotFoundException();
+            throw new MemberNotFoundException(ErrorCode.NON_EXIST_USER);
         }
 
         blueprintService.updateBlueprint(blueprintResponse);
@@ -46,7 +47,7 @@ public class BlueprintController {
     public ApiResponse<String> deleteBlueprint(@PathVariable("id") Long id,
                                                @AuthenticationPrincipal PrincipalDetails principalDetails){
         if(principalDetails == null) {
-            throw new MemberNotFoundException();
+            throw new MemberNotFoundException(ErrorCode.NON_EXIST_USER);
         }
 
         blueprintService.deleteBlueprint(id);

--- a/server/src/main/java/com/onetool/server/api/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/api/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.onetool.server.global.auth.jwt.JwtUtil;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
 import com.onetool.server.global.exception.MemberNotFoundException;
+import com.onetool.server.global.exception.codes.ErrorCode;
 import com.onetool.server.global.exception.codes.SuccessCode;
 import com.onetool.server.api.qna.dto.response.QnaBoardResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -97,7 +98,7 @@ public class MemberController {
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         if (principalDetails == null) {
-            throw new MemberNotFoundException();
+            throw new MemberNotFoundException(ErrorCode.NON_EXIST_USER);
         }
 
         Long id = principalDetails.getContext().getId();
@@ -112,7 +113,7 @@ public class MemberController {
     ) {
 
         if (principalDetails == null) {
-            throw new MemberNotFoundException();
+            throw new MemberNotFoundException(ErrorCode.NON_EXIST_USER);
         }
 
 
@@ -127,7 +128,7 @@ public class MemberController {
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         if (principalDetails == null) {
-            throw new MemberNotFoundException();
+            throw new MemberNotFoundException(ErrorCode.NON_EXIST_USER);
         }
 
         Long id = principalDetails.getContext().getId();

--- a/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
@@ -14,6 +14,7 @@ import com.onetool.server.api.member.repository.MemberRepository;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.order.OrderBlueprint;
 import com.onetool.server.api.qna.QnaBoard;
+import com.onetool.server.global.redis.service.TokenBlackListRedisService;
 import com.onetool.server.global.redis.service.TokenRedisService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,8 @@ public class MemberService {
     private final MailRedisService mailRedisService;
 
     private final TokenRedisService tokenRedisService;
+
+    private final TokenBlackListRedisService tokenBlackListRedisService;
 
     @Value("${spring.mail.auth-code-expiration-millis}")
     private long authCodeExpirationMillis;
@@ -228,7 +231,7 @@ public class MemberService {
 
     public ApiResponse<String> logout(String accessToken, String email) {
         Long expiration = jwtUtil.getExpirationMilliSec(accessToken);
-        tokenRedisService.setBlackList(accessToken, expiration);
+        tokenBlackListRedisService.setBlackList(accessToken, expiration);
         if(tokenRedisService.hasKey(email)) {
             tokenRedisService.deleteValues(email);
         } else {

--- a/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
@@ -71,7 +71,7 @@ public class MemberService {
         String email = request.getEmail();
         String password = request.getPassword();
 
-        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByEmail(email).orElseThrow();
         log.info("============== 로그인 유저 정보 ===============");
         log.info(member.toString());
 
@@ -94,8 +94,7 @@ public class MemberService {
         String name = request.name();
         String phoneNum = request.phone_num();
 
-        Member member = memberRepository.findByNameAndPhoneNum(name, phoneNum)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByNameAndPhoneNum(name, phoneNum).orElseThrow();
 
         return member.getEmail();
     }
@@ -142,8 +141,7 @@ public class MemberService {
 
     public boolean findLostPwd(MemberFindPwdRequest request) {
         String email = request.getEmail();
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByEmail(email).orElseThrow();
 
         String newPwd = createRandomPassword();
         member.setPassword(encoder.encode(newPwd));
@@ -159,8 +157,7 @@ public class MemberService {
 
     @Transactional
     public Member updateMember(Long id, MemberUpdateRequest request) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findById(id).orElseThrow();
 
         member.updateWith(request);
 
@@ -169,8 +166,7 @@ public class MemberService {
 
     @Transactional
     public void deleteMember(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findById(id).orElseThrow();
 
         memberRepository.delete(member);
     }
@@ -191,8 +187,7 @@ public class MemberService {
     }
 
     public MemberInfoResponse getMemberInfo(Long userId) {
-        Member member = memberRepository.findByIdAndIsDeleted(userId,false)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByIdAndIsDeleted(userId,false).orElseThrow();
 
         return MemberInfoResponse.from(member);
     }
@@ -209,8 +204,7 @@ public class MemberService {
     }
 
     public List<BlueprintDownloadResponse> getPurchasedBlueprints(final Long userId) {
-        final Member member = memberRepository.findById(userId)
-                .orElseThrow(MemberNotFoundException::new);
+        final Member member = memberRepository.findById(userId).orElseThrow();
 
         return member.getOrders().stream()
                 .flatMap(order -> order.getOrderItems().stream())

--- a/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
+++ b/server/src/main/java/com/onetool/server/global/auth/jwt/JwtUtil.java
@@ -6,6 +6,7 @@ import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.auth.login.service.CustomUserDetailsService;
 import com.onetool.server.global.redis.domain.Token;
 import com.onetool.server.global.redis.repository.TokenRepository;
+import com.onetool.server.global.redis.service.TokenBlackListRedisService;
 import com.onetool.server.global.redis.service.TokenRedisService;
 import io.jsonwebtoken.*;
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,14 +43,14 @@ public class JwtUtil implements AuthorizationProvider {
     private final Long refreshTokenExpirationMillis;
 
     private final TokenRedisService tokenRedisService;
-    private final TokenRepository tokenRepository;
+    private final TokenBlackListRedisService tokenBlackListRedisService;
     private final CustomUserDetailsService customUserDetailsService;
 
     public JwtUtil(
             @Value("${onetool.jwt.secrekey}") String secretKey,
             @Value("${onetool.jwt.expiration_time}") Long expirationMilliSec,
             @Value("${onetool.jwt.refresh.expiration_time}") Long refreshTokenExpirationMillis,
-            TokenRepository tokenRepository,
+            TokenBlackListRedisService tokenBlackListRedisService,
             CustomUserDetailsService customUserDetailsService,
             TokenRedisService tokenRedisService
             ) {
@@ -58,7 +59,7 @@ public class JwtUtil implements AuthorizationProvider {
         this.key = new SecretKeySpec(keyBytes, "HmacSHA256");
         this.expirationMilliSec = expirationMilliSec;
         this.refreshTokenExpirationMillis = refreshTokenExpirationMillis;
-        this.tokenRepository = tokenRepository;
+        this.tokenBlackListRedisService = tokenBlackListRedisService;
         this.customUserDetailsService = customUserDetailsService;
         this.tokenRedisService = tokenRedisService;
     }
@@ -96,6 +97,9 @@ public class JwtUtil implements AuthorizationProvider {
         try{
             log.info("validateToken token: {}", token);
             Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            if(tokenBlackListRedisService.hasKey(token)) {
+                return false;
+            }
             return true;
         } catch(io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("Invalid JWT Token", e);

--- a/server/src/main/java/com/onetool/server/global/exception/IllegalLogoutMember.java
+++ b/server/src/main/java/com/onetool/server/global/exception/IllegalLogoutMember.java
@@ -1,0 +1,9 @@
+package com.onetool.server.global.exception;
+
+import com.onetool.server.global.exception.codes.BaseCode;
+
+public class IllegalLogoutMember extends BaseException {
+    public IllegalLogoutMember(BaseCode code) {
+        super(code);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/MemberNotFoundException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/MemberNotFoundException.java
@@ -1,5 +1,9 @@
 package com.onetool.server.global.exception;
 
-public class MemberNotFoundException extends RuntimeException {
-    public MemberNotFoundException(){}
+import com.onetool.server.global.exception.codes.BaseCode;
+
+public class MemberNotFoundException extends BaseException {
+    public MemberNotFoundException(BaseCode code) {
+        super(code);
+    }
 }

--- a/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode implements BaseCode {
 
     //사용자 에러
     NON_EXIST_USER(HttpStatus.NOT_FOUND, "MEMBER-0001", "존재하지 않는 회원입니다"),
+    ILLEGAL_LOGOUT_USER(HttpStatus.BAD_REQUEST, "MEMBER-0002", "이미 로그아웃된 회원입니다."),
 
     //바인딩 에러
     BINDING_ERROR(HttpStatus.BAD_REQUEST, "BINDING-0000", "바인딩에 실패했습니다."),

--- a/server/src/main/java/com/onetool/server/global/redis/config/RedisConfig.java
+++ b/server/src/main/java/com/onetool/server/global/redis/config/RedisConfig.java
@@ -31,6 +31,9 @@ public class RedisConfig {
     }
 
     @Bean
+    public RedisConnectionFactory redisConnectionFactory2() {return createRedis(2);}
+
+    @Bean
     public RedisTemplate<String, Object> mailRedisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
@@ -45,6 +48,15 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory1());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> tokenBlackListRedisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory2());
         return redisTemplate;
     }
 

--- a/server/src/main/java/com/onetool/server/global/redis/service/TokenBlackListRedisService.java
+++ b/server/src/main/java/com/onetool/server/global/redis/service/TokenBlackListRedisService.java
@@ -1,0 +1,48 @@
+package com.onetool.server.global.redis.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+public class TokenBlackListRedisService {
+
+    private final RedisTemplate<String, Object> tokenBlackListRedisTemplate;
+
+    public TokenBlackListRedisService(
+            @Qualifier("tokenBlackListRedisTemplate")
+            RedisTemplate<String, Object> tokenBlackListRedisTemplate
+    ) {
+        this.tokenBlackListRedisTemplate = tokenBlackListRedisTemplate;
+    }
+
+    public void setBlackList(String accessToken, Long expiration) {
+        tokenBlackListRedisTemplate.opsForValue()
+                .set(accessToken, "BlackList", expiration, TimeUnit.MINUTES);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, Object> values = tokenBlackListRedisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void deleteValues(String memberId) {
+        ValueOperations<String, Object> values = tokenBlackListRedisTemplate.opsForValue();
+        values.getAndDelete(memberId);
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(tokenBlackListRedisTemplate.hasKey(key));
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/redis/service/TokenRedisService.java
+++ b/server/src/main/java/com/onetool/server/global/redis/service/TokenRedisService.java
@@ -1,5 +1,6 @@
 package com.onetool.server.global.redis.service;
 
+import com.onetool.server.global.auth.jwt.JwtUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -21,13 +24,9 @@ public class TokenRedisService {
         this.tokenRedisTemplate = tokenRedisTemplate;
     }
 
-    public void setValuesWithTimeout(String s, String refreshToken, Long refreshTokenExpirationMillis) {
+    public void setValuesWithTimeout(String email, String refreshToken, Long refreshTokenExpirationMillis) {
         ValueOperations<String, Object> values = tokenRedisTemplate.opsForValue();
-        values.set(
-                s,
-                refreshToken,
-                Duration.ofSeconds(refreshTokenExpirationMillis)
-        );
+        values.set(email, refreshToken, Duration.ofSeconds(refreshTokenExpirationMillis));
     }
 
     @Transactional(readOnly = true)
@@ -42,5 +41,14 @@ public class TokenRedisService {
     public void deleteValues(String memberId) {
         ValueOperations<String, Object> values = tokenRedisTemplate.opsForValue();
         values.getAndDelete(memberId);
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(tokenRedisTemplate.hasKey(key));
+    }
+
+    public void setBlackList(String accessToken, Long expiration) {
+        tokenRedisTemplate.opsForValue()
+                .set(accessToken, "BlackList", expiration, TimeUnit.MINUTES);
     }
 }

--- a/server/src/main/java/com/onetool/server/global/redis/service/TokenRedisService.java
+++ b/server/src/main/java/com/onetool/server/global/redis/service/TokenRedisService.java
@@ -38,17 +38,12 @@ public class TokenRedisService {
         return (String) values.get(key);
     }
 
-    public void deleteValues(String memberId) {
+    public void deleteValues(String email) {
         ValueOperations<String, Object> values = tokenRedisTemplate.opsForValue();
-        values.getAndDelete(memberId);
+        values.getAndDelete(email);
     }
 
     public boolean hasKey(String key) {
         return Boolean.TRUE.equals(tokenRedisTemplate.hasKey(key));
-    }
-
-    public void setBlackList(String accessToken, Long expiration) {
-        tokenRedisTemplate.opsForValue()
-                .set(accessToken, "BlackList", expiration, TimeUnit.MINUTES);
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #123 

## 🔎 작업 내용

### 🔌로그아웃 관련
로그아웃 요청 시, 요청된 accessToken을 남은 기간동안 BlackList에 등재하고 RefreshToken을 Redis에서 삭제됩니다.
로그아웃된 accessToken은 사용할 수 없도록 유효기간을 TTL로 설정하여, 해당 Redis에 저장된 경우 사용할 수 없도록 구현했어요.


### 💽Redis 관련
현재 **총 3개의 Redis 데이터베이스**를 사용하고 있어요.

| 순서 | {키, 값} | 사용 목적 |
|---|---|---|
| 1 | {email, refreshToken} | 토큰 재발급 시, 토큰 유효성 검사 |
| 2 | {email, 인증코드} | 이메일 인증을 위한 인증코드 저장 |
| 3 | {accessToken, "BlackList"} | 로그아웃된 accessToken 사용 방지 |

Redis 사용에 대한 Wiki를 추가로 남겨보겠습니다.
또한, Redis 데이터베이스를 조회할 수 있는 명령어도 남겨봐요.
```bash
# Redis 진입 (-n 데이터베이스 번호)
redis-cli -n 1

# 데이터베이스에 저장된 Key들 조회
keys *
```

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

커스텀 예외 중 BaseException을 상속받지 않아 모든 에러가 StackTrace되는 문제가 있어요. 또한 커스텀 예외 계층화를 통한 ControllerAdvice의 코드를 줄이는 과정도 필요해보여요!
관련된 PR 링크도 남겨봅니다.
[커스텀 예외 리펙터링 PR](https://github.com/ICT-Dev-Route/Dev-Route-BE/pull/140)

## 🧲 참고 자료 및 공유 사항
[Redis BlackList 구현](https://velog.io/@ch0jm/lnwfrngd)
[로그아웃 구현](https://velog.io/@boo105/Redis-%EB%A5%BC-%ED%86%B5%ED%95%9C-JWT-Blacklist-%EA%B5%AC%ED%98%84)

