### PR TITLE
refator: CategoryName별로 정렬 기능

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/controller/SearchController.java
@@ -107,16 +107,16 @@ public class SearchController {
         return ApiResponse.onSuccess(blueprintResponseDTO);
     }
 
-    @GetMapping({"/blueprint/sort", "/blueprint/{categoryId}/sort"})
+    @GetMapping({"/blueprint/sort", "/blueprint/{categoryName}/sort"})
     public ApiResponse<List<BlueprintResponse>> sortBlueprints(
-            @PathVariable(name = "categoryId", value = "categoryId", required = false) Long categoryId,
+            @PathVariable(name = "categoryName", required = false) String categoryName,
             @RequestParam(name = "sortBy") String sortBy,
             @RequestParam(name = "sortOrder", required = false, defaultValue = "asc") String sortOrder,
             Pageable pageable
     ) {
-        BlueprintSortRequest request = new BlueprintSortRequest(categoryId, sortBy, sortOrder);
-        List<BlueprintResponse> sortedItems = blueprintSearchService.sortBlueprintsByCategory(request, pageable);
+        List<BlueprintResponse> sortedItems = blueprintSearchService.sortBlueprints(categoryName, sortBy, sortOrder, pageable);
         return ApiResponse.onSuccess(sortedItems);
     }
+
 
 }

--- a/server/src/main/java/com/onetool/server/api/blueprint/controller/SearchController.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/controller/SearchController.java
@@ -114,9 +114,8 @@ public class SearchController {
             @RequestParam(name = "sortOrder", required = false, defaultValue = "asc") String sortOrder,
             Pageable pageable
     ) {
-        List<BlueprintResponse> sortedItems = blueprintSearchService.sortBlueprints(categoryName, sortBy, sortOrder, pageable);
+        BlueprintSortRequest request = new BlueprintSortRequest(categoryName, sortBy, sortOrder);
+        List<BlueprintResponse> sortedItems = blueprintSearchService.sortBlueprints(request, pageable);
         return ApiResponse.onSuccess(sortedItems);
     }
-
-
 }

--- a/server/src/main/java/com/onetool/server/api/blueprint/dto/BlueprintSortRequest.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/dto/BlueprintSortRequest.java
@@ -1,7 +1,7 @@
 package com.onetool.server.api.blueprint.dto;
 
 public record BlueprintSortRequest(
-        Long categoryId,
+        String categoryName,
         String sortBy,
         String sortOrder
 ) {}

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintSearchService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintSearchService.java
@@ -39,20 +39,14 @@ public class BlueprintSearchService {
         return BlueprintResponse.from(blueprint);
     }
 
-    public List<BlueprintResponse> sortBlueprints(
-            String categoryName,
-            String sortBy,
-            String sortOrder,
-            Pageable pageable
-    ) {
-        Sort sort = SortType.getSortBySortType(SortType.valueOf(sortBy.toUpperCase()), sortOrder);
+    public List<BlueprintResponse> sortBlueprints(BlueprintSortRequest request, Pageable pageable) {
+        Long categoryId = getCategoryId(request.categoryName());
+        Sort sort = SortType.getSortBySortType(SortType.valueOf(request.sortBy().toUpperCase()), request.sortOrder());
         Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
-        if (categoryName == null) {
+        if (categoryId == null) {
             return sortBlueprintsWithoutCategory(sortedPageable);
         }
-        FirstCategoryType categoryType = FirstCategoryType.findByType(categoryName);
-        Long categoryId = categoryType.getCategoryId();
 
         return sortBlueprintsWithCategory(categoryId, sortedPageable);
     }
@@ -116,5 +110,12 @@ public class BlueprintSearchService {
         return blueprints.stream()
                 .map(SearchResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    private Long getCategoryId(String categoryName) {
+        if (categoryName == null) {
+            return null;
+        }
+        return FirstCategoryType.findByType(categoryName).getCategoryId();
     }
 }

--- a/server/src/main/java/com/onetool/server/api/category/FirstCategoryType.java
+++ b/server/src/main/java/com/onetool/server/api/category/FirstCategoryType.java
@@ -1,6 +1,7 @@
 package com.onetool.server.api.category;
 
 import com.onetool.server.global.exception.CategoryNotFoundException;
+import com.onetool.server.global.exception.codes.ErrorCode;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -26,13 +27,13 @@ public enum FirstCategoryType {
         return Arrays.stream(values())
                 .filter(category -> category.getCategoryId().equals(categoryId))
                 .findFirst()
-                .orElseThrow(CategoryNotFoundException::new);
+                .orElseThrow(() -> new CategoryNotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
     public static FirstCategoryType findByType(String type) {
         return Arrays.stream(values())
                 .filter(category -> category.getType().equalsIgnoreCase(type))
                 .findFirst()
-                .orElseThrow(CategoryNotFoundException::new);
+                .orElseThrow(() -> new CategoryNotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 }

--- a/server/src/main/java/com/onetool/server/api/category/FirstCategoryType.java
+++ b/server/src/main/java/com/onetool/server/api/category/FirstCategoryType.java
@@ -1,6 +1,9 @@
 package com.onetool.server.api.category;
 
+import com.onetool.server.global.exception.CategoryNotFoundException;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Getter
 public enum FirstCategoryType {
@@ -20,20 +23,16 @@ public enum FirstCategoryType {
     }
 
     public static FirstCategoryType findByCategoryId(Long categoryId) {
-        for (FirstCategoryType category : values()) {
-            if (category.getCategoryId().equals(categoryId)) {
-                return category;
-            }
-        }
-        throw new IllegalArgumentException("Invalid category ID: " + categoryId);
+        return Arrays.stream(values())
+                .filter(category -> category.getCategoryId().equals(categoryId))
+                .findFirst()
+                .orElseThrow(CategoryNotFoundException::new);
     }
 
     public static FirstCategoryType findByType(String type) {
-        for (FirstCategoryType category : values()) {
-            if (category.getType().equalsIgnoreCase(type)) {
-                return category;
-            }
-        }
-        throw new IllegalArgumentException("Invalid category type: " + type);
+        return Arrays.stream(values())
+                .filter(category -> category.getType().equalsIgnoreCase(type))
+                .findFirst()
+                .orElseThrow(CategoryNotFoundException::new);
     }
 }

--- a/server/src/main/java/com/onetool/server/api/category/FirstCategoryType.java
+++ b/server/src/main/java/com/onetool/server/api/category/FirstCategoryType.java
@@ -4,17 +4,36 @@ import lombok.Getter;
 
 @Getter
 public enum FirstCategoryType {
-    CATEGORY_BUILDING("building"),
-    CATEGORY_CIVIL("civil"),
-    CATEGORY_INTERIOR("interior"),
-    CATEGORY_MACHINE("machine"),
-    CATEGORY_ELECTRIC("electric"),
-    CATEGORY_ETC("etc");
+    CATEGORY_BUILDING(1L, "building"),
+    CATEGORY_CIVIL(2L, "civil"),
+    CATEGORY_INTERIOR(3L, "interior"),
+    CATEGORY_MACHINE(4L, "machine"),
+    CATEGORY_ELECTRIC(5L, "electric"),
+    CATEGORY_ETC(6L, "etc");
 
+    private final Long categoryId;
     private final String type;
 
-    FirstCategoryType(String type) {
+    FirstCategoryType(Long categoryId, String type) {
+        this.categoryId = categoryId;
         this.type = type;
     }
 
+    public static FirstCategoryType findByCategoryId(Long categoryId) {
+        for (FirstCategoryType category : values()) {
+            if (category.getCategoryId().equals(categoryId)) {
+                return category;
+            }
+        }
+        throw new IllegalArgumentException("Invalid category ID: " + categoryId);
+    }
+
+    public static FirstCategoryType findByType(String type) {
+        for (FirstCategoryType category : values()) {
+            if (category.getType().equalsIgnoreCase(type)) {
+                return category;
+            }
+        }
+        throw new IllegalArgumentException("Invalid category type: " + type);
+    }
 }

--- a/server/src/main/java/com/onetool/server/global/exception/CategoryNotFoundException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/CategoryNotFoundException.java
@@ -1,0 +1,6 @@
+package com.onetool.server.global.exception;
+
+public class CategoryNotFoundException extends RuntimeException {
+    public CategoryNotFoundException() {
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/exception/CategoryNotFoundException.java
+++ b/server/src/main/java/com/onetool/server/global/exception/CategoryNotFoundException.java
@@ -1,6 +1,9 @@
 package com.onetool.server.global.exception;
 
-public class CategoryNotFoundException extends RuntimeException {
-    public CategoryNotFoundException() {
+import com.onetool.server.global.exception.codes.BaseCode;
+
+public class CategoryNotFoundException extends BaseException {
+    public CategoryNotFoundException(BaseCode code) {
+        super(code);
     }
 }

--- a/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
@@ -78,6 +78,9 @@ public enum ErrorCode implements BaseCode {
     //도면 에러
     NO_BLUEPRINT_FOUND(HttpStatus.NOT_FOUND, "BLUEPRINT-0000", "도면이 존재하지 않습니다."),
 
+    //카테고리 에러
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY-0000", "존재하지 않는 카테고리입니다."),
+
     //장바구니 에러
     NO_ITEM_IN_CART(HttpStatus.NO_CONTENT, "CART-0000", "장바구니에 상품이 없습니다."),
     ALREADY_EXIST_BLUEPRINT_IN_CART(HttpStatus.BAD_REQUEST, "CART-0001", "장바구니에 존재하는 상품입니다."),

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -69,6 +69,11 @@ public class ExceptionAdvice {
         return ApiResponse.onFailure("403", "승인받지 않은 도면입니다.", null);
     }
 
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ApiResponse<?> CategoryNotFoundException (CategoryNotFoundException  e) {
+        return ApiResponse.onFailure("400", "올바르지 않은 카테고리입니다.", null);
+    }
+
     /**
      * 서버 에러
      * @param e

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -60,7 +60,7 @@ public class ExceptionAdvice {
     }
 
     @ExceptionHandler(InvalidSortTypeException.class)
-    public ApiResponse<?> handleInvalidSortTypeException(InvalidSortTypeException e) {
+    public ApiResponse<?> InvalidSortTypeException(InvalidSortTypeException e) {
         return ApiResponse.onFailure("400", "올바르지 않은 정렬 방식입니다.", null);
     }
 

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -71,7 +71,7 @@ public class ExceptionAdvice {
 
     @ExceptionHandler(CategoryNotFoundException.class)
     public ApiResponse<?> CategoryNotFoundException (CategoryNotFoundException  e) {
-        return ApiResponse.onFailure("400", "올바르지 않은 카테고리입니다.", null);
+        return ApiResponse.onFailure("404", "존재하지 않는 카테고리입니다.", null);
     }
 
     /**

--- a/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceMockTest.java
+++ b/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceMockTest.java
@@ -219,7 +219,6 @@ public class BlueprintServiceMockTest {
                 .andExpect(content().string(objectMapper.writeValueAsString(ApiResponse.onSuccess("상품이 정상적으로 삭제 되었습니다."))));
     }
 
-
     @DisplayName("카테고리 없이 blueprint를 정렬한다.")
     @Test
     void blueprintWithoutCategorySortTest() throws Exception {
@@ -231,7 +230,8 @@ public class BlueprintServiceMockTest {
                 BlueprintResponse.builder().id(2L).blueprintName("골프장 레이아웃 평면도(1)").build()
         );
 
-        Mockito.when(blueprintSearchService.sortBlueprints(null, sortBy, sortOrder, pageable))
+        Mockito.when(blueprintSearchService.sortBlueprints(
+                        new BlueprintSortRequest(null, sortBy, sortOrder), pageable))
                 .thenReturn(mockResponse);
 
         // when & then
@@ -259,12 +259,14 @@ public class BlueprintServiceMockTest {
                 BlueprintResponse.builder().id(2L).blueprintName("골프장 레이아웃 평면도(1)").categoryId(1L).build()
         );
 
+        BlueprintSortRequest request = new BlueprintSortRequest(categoryName, sortBy, sortOrder);
+
         // 카테고리별 정렬 메서드 mock
-        Mockito.when(blueprintSearchService.sortBlueprints(categoryName, sortBy, sortOrder, pageable))
+        Mockito.when(blueprintSearchService.sortBlueprints(request, pageable))
                 .thenReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get("/blueprint/building/sort")
+        mockMvc.perform(get("/blueprint/{categoryName}/sort", categoryName)
                         .param("sortBy", sortBy)
                         .param("sortOrder", sortOrder)
                         .param("page", "0")


### PR DESCRIPTION
## #️⃣ 이슈

- close #98
- 
## 🔎 작업 내용

### refator: CategoryName별로 정렬 기능

- 기존에 `categoryId`를 통해 카테고리별 정렬을 하던 것에서 `categoryName`을 통해 정렬 가능하도록 구현
- `FirstCategoryType` 에 categoryId 추가 수정 
<img width="311" alt="image" src="https://github.com/user-attachments/assets/3ce5067b-86cc-43ea-87ea-8e8ee9eb9ee3" />

-`BlueprintSearchController`에서 categoryName을 입력받는다. `BlueprintService`에서 categoryName을 통해 도면에 저장된 categoryId를 찾는다. 해당되는 도면에 대한 정렬을 반환한다.

<img width="602" alt="image" src="https://github.com/user-attachments/assets/eb935463-ee64-4086-93f2-0e2c08fa57b5" />


## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
- 문제가 있는 부분 알려주세요! 

+) `BlueprintServiceMockTest` ` @DisplayName("새 blueprint가 정상적으로 생성되는지 확인")` 같이 로그인 인증이 필요한 테스트들이 403 오류 발생, 수정해야함 


## 🧲 참고 자료 및 공유 사항


