### PR TITLE
feat(toss): 결제승인 API

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -50,7 +50,6 @@ dependencies {
 
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
 	implementation 'javax.mail:javax.mail-api:1.6.2'
-	//implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
 	implementation 'com.sun.mail:smtp:2.0.1'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -61,7 +60,10 @@ dependencies {
 	testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/onetool/server/api/payments/controller/PaymentController.java
+++ b/server/src/main/java/com/onetool/server/api/payments/controller/PaymentController.java
@@ -1,0 +1,117 @@
+package com.onetool.server.api.payments.controller;
+
+import com.onetool.server.api.payments.domain.PaymentProperties;
+import com.onetool.server.api.payments.dto.PaymentErrorResponse;
+import com.onetool.server.api.payments.domain.TossPaymentMethod;
+import com.onetool.server.api.payments.dto.SaveAmountRequest;
+import com.onetool.server.api.payments.repository.PaymentRepository;
+import com.onetool.server.api.payments.service.PaymentService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Slf4j
+@RestController
+public class PaymentController {
+
+    private final PaymentProperties properties;
+    private final PaymentService paymentService;
+
+    public PaymentController(PaymentProperties properties, PaymentService paymentService) {
+        this.properties = properties;
+        this.paymentService = paymentService;
+    }
+
+    @PostMapping("/saveAmount")
+    public ResponseEntity<?> tempSave(HttpSession session, @RequestBody SaveAmountRequest saveAmountRequest) {
+        session.setAttribute(saveAmountRequest.orderId(), saveAmountRequest.amount());
+        return ResponseEntity.ok("Payment temp save successful");
+    }
+
+    @PostMapping("/verifyAmount")
+    public ResponseEntity<?> verifyAmount(HttpSession session, @RequestBody SaveAmountRequest saveAmountRequest) {
+        String amount = (String) session.getAttribute(saveAmountRequest.orderId());
+
+        if(amount == null || !amount.equals(saveAmountRequest.amount())) {
+            return ResponseEntity.badRequest().body(PaymentErrorResponse.builder().code(400).message("결제 금액 정보가 유효하지 않습니다.").build());
+        }
+
+        session.removeAttribute(saveAmountRequest.orderId());
+
+        return ResponseEntity.ok("Payment is valid");
+    }
+
+    @RequestMapping(value = "/payments/confirm")
+    public ResponseEntity<JSONObject> confirmPayment(@RequestBody SaveAmountRequest requestData) throws Exception {
+        JSONParser parser = new JSONParser();
+        String authorizationHeader = createAuthorizationHeader();
+        JSONObject response = sendPaymentConfirmation(requestData, authorizationHeader, parser);
+        paymentService.savePayment(response);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/cancel")
+    public HttpResponse requestPaymentCancel(HttpServletRequest servletRequest, String paymentKey, String cancelReason) throws IOException, InterruptedException {
+        log.info("cancel paymentKey : {}", paymentKey);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("<https://api.toospayments.com/v1/payments/>" + paymentKey + "/cancel"))
+                .header("Authorization", createAuthorizationHeader())
+                .header("Content-Type", "application/json")
+                .method("POST", HttpRequest.BodyPublishers.ofString("{\"cancelReason\":\"" + cancelReason + "\"}"))
+                .build();
+        return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private String createAuthorizationHeader() {
+        // 토스페이먼츠 API는 시크릿 키를 사용자 ID로 사용하고, 비밀번호는 사용하지 않습니다.
+        // 비밀번호가 없다는 것을 알리기 위해 시크릿 키 뒤에 콜론을 추가합니다.
+        Base64.Encoder encoder = Base64.getEncoder();
+        byte[] encodedBytes = encoder.encode((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
+        log.info(Arrays.toString(encodedBytes));
+        return "Basic " + new String(encodedBytes);
+    }
+
+    private JSONObject sendPaymentConfirmation(SaveAmountRequest requestData, String authorizationHeader, JSONParser parser) throws IOException {
+        // 결제를 승인하면 결제수단에서 금액이 차감돼요.
+        log.info(authorizationHeader);
+        URL url = new URL(properties.getConfirmURL());
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestProperty("Authorization", authorizationHeader);
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+
+        log.info(requestData.toString());
+
+        try(OutputStream outputStream = connection.getOutputStream()) {
+            outputStream.write(requestData.toString().getBytes(StandardCharsets.UTF_8));
+        }
+
+        int code = connection.getResponseCode();
+        try (InputStream responseStream = code == 200 ? connection.getInputStream() : connection.getErrorStream();
+            Reader reader = new InputStreamReader(responseStream, StandardCharsets.UTF_8)) {
+            return (JSONObject) parser.parse(reader);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/payments/domain/PaymentProperties.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/PaymentProperties.java
@@ -1,0 +1,14 @@
+package com.onetool.server.api.payments.domain;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class PaymentProperties {
+    @Value("${toss.payment.secret-key}")
+    private String secretKey;
+    @Value("${toss.payment.confirm-url}")
+    private String confirmURL;
+}

--- a/server/src/main/java/com/onetool/server/api/payments/domain/TossPayment.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/TossPayment.java
@@ -1,0 +1,38 @@
+package com.onetool.server.api.payments.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.onetool.server.api.order.Orders;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TossPayment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @Column(nullable = false, unique = true)
+    String tossPaymentKey;
+
+    @Column(unique = false)
+    String tossOrderId;
+
+    long totalAmount;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    TossPaymentMethod tossPaymentMethod;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    TossPaymentStatus tossPaymentStatus;
+
+    LocalDateTime requestedAt;
+    LocalDateTime approvedAt;
+}

--- a/server/src/main/java/com/onetool/server/api/payments/domain/TossPaymentMethod.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/TossPaymentMethod.java
@@ -1,0 +1,24 @@
+package com.onetool.server.api.payments.domain;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+public enum TossPaymentMethod {
+    가상계좌,
+    간편결제,
+    게임문화상품권,
+    계좌이체,
+    도서문화상품권,
+    문화상품권,
+    카드,
+    휴대폰;
+
+    @Override
+    public String toString() {
+        return this.name();
+    }
+
+
+}

--- a/server/src/main/java/com/onetool/server/api/payments/domain/TossPaymentStatus.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/TossPaymentStatus.java
@@ -1,0 +1,17 @@
+package com.onetool.server.api.payments.domain;
+
+public enum TossPaymentStatus {
+    ABORTED,
+    CANCELED,
+    DONE,
+    EXPIRED,
+    IN_PROGRESS,
+    PARTIAL_CANCELED,
+    READY,
+    WAITING_FOR_DEPOSIT;
+
+    @Override
+    public String toString() {
+        return this.name();
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/payments/dto/PaymentErrorResponse.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/PaymentErrorResponse.java
@@ -1,0 +1,11 @@
+package com.onetool.server.api.payments.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentErrorResponse(
+        int code,
+        String message
+) {
+
+}

--- a/server/src/main/java/com/onetool/server/api/payments/dto/SaveAmountRequest.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/SaveAmountRequest.java
@@ -1,0 +1,19 @@
+package com.onetool.server.api.payments.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public record SaveAmountRequest(
+        String paymentKey,
+        String amount,
+        String orderId
+) {
+    @Override
+    public String toString() {
+        try {
+            return new ObjectMapper().writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/payments/repository/PaymentRepository.java
+++ b/server/src/main/java/com/onetool/server/api/payments/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.onetool.server.api.payments.repository;
+
+import com.onetool.server.api.payments.domain.TossPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<TossPayment, Long> {
+}

--- a/server/src/main/java/com/onetool/server/api/payments/service/PaymentService.java
+++ b/server/src/main/java/com/onetool/server/api/payments/service/PaymentService.java
@@ -1,0 +1,47 @@
+package com.onetool.server.api.payments.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.onetool.server.api.payments.domain.TossPayment;
+import com.onetool.server.api.payments.domain.TossPaymentMethod;
+import com.onetool.server.api.payments.domain.TossPaymentStatus;
+import com.onetool.server.api.payments.repository.PaymentRepository;
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    public PaymentService(PaymentRepository paymentRepository) {
+        this.paymentRepository = paymentRepository;
+    }
+
+    public void savePayment(JSONObject response) {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+        String method = (String) response.get("method");
+        String paymentKey = (String) response.get("paymentKey");
+        String orderId = (String) response.get("orderId");
+        LocalDateTime requestedAt = LocalDateTime.parse((String) response.get("requestedAt"), formatter);
+        LocalDateTime approvedAt = LocalDateTime.parse((String) response.get("approvedAt"), formatter);
+        Long totalAmount = (Long) response.get("totalAmount");
+        String status = (String) response.get("status");
+
+        TossPayment tossPayment = TossPayment.builder()
+                .tossPaymentKey(paymentKey)
+                .tossOrderId(orderId)
+                .tossPaymentMethod(TossPaymentMethod.valueOf(method))
+                .tossPaymentStatus(TossPaymentStatus.valueOf(status))
+                .requestedAt(requestedAt)
+                .approvedAt(approvedAt)
+                .totalAmount(totalAmount)
+                .build();
+
+        paymentRepository.save(tossPayment);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/onetool/server/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     private static final String[] AUTH_WHITELIST = {
-            "/users/**", "/login/**", "/blueprint/**", "/actuator/health", "/silent-refresh"
+            "/users/**", "/login/**", "/blueprint/**", "/actuator/health", "/silent-refresh", "/payments/**"
     };
 
     @Bean
@@ -101,6 +101,7 @@ public class SecurityConfig {
         configuration.addAllowedOrigin("http://onetool.co.kr");
         configuration.addAllowedOrigin("http://localhost:3000");
         configuration.addAllowedOrigin("https://accounts.google.com");
+        configuration.addAllowedOrigin("https://api.tosspayments.com");
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -76,7 +76,7 @@ public class ExceptionAdvice {
      */
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e) {
-        log.error(e.getMessage());
+        log.error(e.getMessage(), e);
         ErrorCode errorCode = ErrorCode._INTERNAL_SERVER_ERROR;
         ApiResponse<?> baseResponse = ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null);
         return handleExceptionInternal(baseResponse);
@@ -89,6 +89,7 @@ public class ExceptionAdvice {
      */
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<Object> onThrowException(BaseException generalException) {
+        log.error("BaseException", generalException);
         Reason.ReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
         ApiResponse<?> baseResponse = ApiResponse.onFailure(errorReasonHttpStatus.getCode(), errorReasonHttpStatus.getMessage(), null);
         return handleExceptionInternal(baseResponse);
@@ -189,11 +190,11 @@ public class ExceptionAdvice {
      * @param e NoHandlerFoundException
      * @return ResponseEntity<ErrorResponse>
      */
-//    @ExceptionHandler(NoHandlerFoundException.class)
-//    protected ResponseEntity<Object> handleNoHandlerFoundExceptionException(NoHandlerFoundException e) {
-//        log.error("handleNoHandlerFoundExceptionException", e);
-//        return handleExceptionInternal(ErrorCode.NOT_FOUND_ERROR);
-//    }
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<Object> handleNoHandlerFoundExceptionException(NoHandlerFoundException e) {
+        log.error("handleNoHandlerFoundExceptionException", e);
+        return handleExceptionInternal(ErrorCode.NOT_FOUND_ERROR);
+    }
 
     private ResponseEntity<Object> handleExceptionInternal(ApiResponse<?> response) {
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -17,3 +17,6 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.config.import=optional:application-api.properties
 
 logging.level.org.hibernate.type=trace
+
+toss.payment.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+toss.payment.confirm-url=https://api.tosspayments.com/v1/payments/confirm


### PR DESCRIPTION
## #️⃣ 이슈

- close #127 

## 🔎 작업 내용

### 토스페이먼츠 API의 흐름
먼저 토스페이먼츠 API가 어떤 식으로 작동하는지를 설명드릴께요!

![image](https://github.com/user-attachments/assets/9d94048f-df29-4b61-933b-46917da0fd75)

클라이언트에서 최종 결제 승인을 위해 **백엔드 서버에 결제 승인**을 하게 됩니다. 결제 승인 요청을 받은 백엔드 서버는 요청에 담긴 `paymentKey`와 `orderId`를 데이터베이스에 저장을 하고, **토스페이먼츠에 최종 결제 확인을 요청**합니다.
최종 결제가 될 경우, 클라이언트에게 완료 여부를 남깁니다.

오류가 발생할 경우, 토스페이먼츠 서버에서 반환하는 오류 코드를 통해 핸들링이 가능해요.
백엔드 서버에선 토스페이먼츠에서 전달받은 메시지는 **별도의 가공없이 Raw로 클라이언트에 전송**하도록 구현했습니다.

### 추가 검증 과정
가이드 라인에서 값의 변조를 막기 위해 `Client에서 결제 과정에서 검증을 하는 코드`를 작성하는 것을 권장하고 있어요. 따라서, 아래의 과정과 같이 Session을 통한 검증을 진행할 수 있도록 구현했습니다.

![image](https://github.com/user-attachments/assets/f3e07176-7c95-4dbd-961f-90a5d2138497)

### 추가 설명
- `TossPayment` : 결제 승인 시, 클라이언트로부터 요청받은 PaymentKey, OrderId와 같은 정보를 저장하는 엔티티
-  JSON (역)직렬화를 위한 jackson 라이브러리 의존성 추가

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

### Orders와의 연관관계 매핑은 어떻게?

`Orders`와 `TossPayment`는 일대일 관계를 가집니다. OneToOne으로 관계를 맺어 구현하려고 했으나 **토스 결제 과정에서 Orders에 대한 정보를 어떻게 가져올지** 많이 고민했습니다. `Session`을 통해 가져오는 방법을 생각해냈지만, 구현 과정이 막막하더군요..
주문 조회 시, 결제 정보 또한 조회되도록 구현하기 위해선 필요하다고 생각이 들긴하는데, 구현 방법을 더 조사해보겠습니다!


## 🧲 참고 자료 및 공유 사항
[토스페이먼츠 연동하기](https://jaehee1007.tistory.com/158#%E2%9C%85%C2%A0Toss%20payments%20Spring%20boot%20%EB%B0%B1%EC%97%94%EB%93%9C%20%EC%84%9C%EB%B2%84%20%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-1)
[토스페이먼츠 공식문서](https://docs.tosspayments.com/guides/v2/payment-widget/integration)
