### PR TITLE
fix: 장바구니 읽기, 쓰기, 삭제 버그 수정

### DIFF
--- a/server/src/main/java/com/onetool/server/api/cart/Cart.java
+++ b/server/src/main/java/com/onetool/server/api/cart/Cart.java
@@ -25,7 +25,7 @@ public class Cart extends BaseEntity {
     @JoinColumn(name = "member_cart_id")
     private Member member;
 
-    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<CartBlueprint> cartItems = new ArrayList<>();
 
     private Cart(Member member){

--- a/server/src/main/java/com/onetool/server/api/cart/CartBlueprint.java
+++ b/server/src/main/java/com/onetool/server/api/cart/CartBlueprint.java
@@ -29,7 +29,7 @@ public class CartBlueprint extends BaseEntity {
         this.blueprint = blueprint;
     }
 
-    public static CartBlueprint addBlueprintToCart(Cart cart, Blueprint blueprint){
+    public static CartBlueprint of(Cart cart, Blueprint blueprint){
         return CartBlueprint.builder()
                 .cart(cart)
                 .blueprint(blueprint)

--- a/server/src/main/java/com/onetool/server/api/cart/repository/CartRepository.java
+++ b/server/src/main/java/com/onetool/server/api/cart/repository/CartRepository.java
@@ -1,7 +1,22 @@
 package com.onetool.server.api.cart.repository;
 
 import com.onetool.server.api.cart.Cart;
+import com.onetool.server.api.cart.CartBlueprint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    @Query("SELECT c FROM Cart c JOIN FETCH c.member m WHERE m.id = :memberId")
+    Optional<Cart> findCartIdWithMemberByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT DISTINCT ci FROM CartBlueprint ci WHERE ci.cart.id = :cartId")
+    List<CartBlueprint> findCartBlueprintsByCartId(@Param("cartId") Long cartId);
+
+    @Query("SELECT c.totalPrice FROM Cart c WHERE c.id = :cartId")
+    Long findTotalPriceByCartId(@Param("cartId") Long cartId);
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #134 

## 🔎 작업 내용

- Cart와 CartBlueprint 각각에 대한 save()를 Cart에 대한 save()만 수행하도록 수정
- Transactional을 통한 조회 동기화 문제 해결

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

### JPA의 상태 관리
CartBlueprint 내의 addBlueprintToCart()는 다음과 같다.

```java
public String addBlueprintToCart(MemberAuthContext user, Long blueprintId){

        Member member = findMemberWithCart(user.getId());
        Cart cart = member.getCart();
        Blueprint blueprint = findBlueprint(blueprintId);
        isBlueprintAlreadyInCart(cart, blueprint);
        CartBlueprint newCartBlueprint = CartBlueprint.addBlueprintToCart(cart, blueprint);
        cartBlueprintRepository.save(CartBlueprint.addBlueprintToCart(cart, blueprint));
        updateCartAndSave(cart, newCartBlueprint, Action.ADD);
        return "장바구니에 추가됐습니다.";
    }

```

위 코드에서 
```java
cartBlueprintRepository.save(CartBlueprint.addBlueprintToCart(cart, blueprint));
``` 
를 통해 CartBlueprint 엔티티에 저장이 한 번된다.

```java
cart.getCartItems().add(cartBlueprint);
cartRepository.save(cart);
```
그 이후 위에 코를 통해 Cart에 저장 시, JPA는 Cart와 연관된 CartBlueprint 컬렉션도 확인을 하고 다시 한 번 Cart에 저장을 하게 된다.

따라서 CartBlueprint 컬렉션에 add 후 save는 Cart만 수행하여 해결한다.

### 트랜잭션 처리
```java
public String deleteBlueprintInCart(MemberAuthContext user,
                                  Long blueprintId){

    Member member = findMemberWithCart(user.getId());
    Cart cart = member.getCart();
    CartBlueprint cartBlueprint = findCartBlueprint(cart, blueprintId);
    cartBlueprintRepository.delete(cartBlueprint);
    updateCartAndSave(cart, cartBlueprint, Action.REMOVE);
    return "삭제됐습니다.";
}
```
deleteBlueprintInCart 메서드를 통해 CartBlueprint를 삭제하고, Cart의 cartItems 리스트에서 CartBlueprint를 제거하는 과정을 수행한다. 영속성 컨텍스트와 데이터베이스 상태를 동기화되지 않아, 바로 장바구니 조회 시 업데이트가 반영되지 않는 문제가 발생했다.
따라서 Transactional 어노테이션 적용을 통해 이 문제를 해결했다.

## 🧲 참고 자료 및 공유 사항


