### PR TITLE
feat(order): 주문, 결제 생성 및 조회

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/domain/Member.java
+++ b/server/src/main/java/com/onetool/server/api/member/domain/Member.java
@@ -28,7 +28,8 @@ import java.util.List;
 @SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
 public class Member extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String password;

--- a/server/src/main/java/com/onetool/server/api/order/OrderBlueprint.java
+++ b/server/src/main/java/com/onetool/server/api/order/OrderBlueprint.java
@@ -3,13 +3,13 @@ package com.onetool.server.api.order;
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Builder
 @Entity (name = "order_blueprint")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class OrderBlueprint extends BaseEntity {
 
     @Id

--- a/server/src/main/java/com/onetool/server/api/order/Orders.java
+++ b/server/src/main/java/com/onetool/server/api/order/Orders.java
@@ -1,18 +1,19 @@
 package com.onetool.server.api.order;
 
+import com.onetool.server.api.payments.domain.Payment;
 import com.onetool.server.global.entity.BaseEntity;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.payments.TossPayments;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity(name = "orders")
+@Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Orders extends BaseEntity {
     @Id
@@ -26,12 +27,11 @@ public class Orders extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderBlueprint> orderItems = new ArrayList<>();
 
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_member_id")
     private Member member;
 
-    @OneToOne
-    private TossPayments payments;
+    @OneToOne(mappedBy = "orders")
+    private Payment payment;
 
 }

--- a/server/src/main/java/com/onetool/server/api/order/Orders.java
+++ b/server/src/main/java/com/onetool/server/api/order/Orders.java
@@ -2,7 +2,7 @@ package com.onetool.server.api.order;
 
 import com.onetool.server.global.entity.BaseEntity;
 import com.onetool.server.api.member.domain.Member;
-import com.onetool.server.api.payments.Payments;
+import com.onetool.server.api.payments.TossPayments;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -32,6 +32,6 @@ public class Orders extends BaseEntity {
     private Member member;
 
     @OneToOne
-    private Payments payments;
+    private TossPayments payments;
 
 }

--- a/server/src/main/java/com/onetool/server/api/order/Orders.java
+++ b/server/src/main/java/com/onetool/server/api/order/Orders.java
@@ -1,5 +1,6 @@
 package com.onetool.server.api.order;
 
+import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.payments.domain.Payment;
 import com.onetool.server.global.entity.BaseEntity;
 import com.onetool.server.api.member.domain.Member;
@@ -24,6 +25,7 @@ public class Orders extends BaseEntity {
 
     private int totalCount;
 
+    @Setter
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderBlueprint> orderItems = new ArrayList<>();
 
@@ -33,5 +35,4 @@ public class Orders extends BaseEntity {
 
     @OneToOne(mappedBy = "orders")
     private Payment payment;
-
 }

--- a/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
+++ b/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
@@ -1,29 +1,35 @@
 package com.onetool.server.api.order.controller;
 
+import com.onetool.server.api.order.Orders;
 import com.onetool.server.api.order.dto.request.OrderRequest;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
 import com.onetool.server.api.order.service.OrderServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.onetool.server.api.order.dto.response.OrderResponse.*;
 
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/orders")
 public class OrderController {
 
     private final OrderServiceImpl orderService;
 
-    //결제 페이지로 이동
-    @GetMapping("/orders")
-    public ApiResponse<OrderPageMemberResponseDto> getUserInformationForOrder(@AuthenticationPrincipal PrincipalDetails principal,
-                                                                              @RequestBody OrderRequest request){
-        return ApiResponse.onSuccess(orderService.getMemberInfoForOrder(principal.getContext(), request));
+    @PostMapping
+    public ApiResponse<String> createOrders(@AuthenticationPrincipal PrincipalDetails principal,
+                                                          @RequestBody OrderRequest request){
+        orderService.makeOrder(principal.getContext(), request);
+        return ApiResponse.onSuccess("주문 생성이 완료되었습니다.");
     }
 
+    @GetMapping
+    public ApiResponse<List<MyPageOrderResponseDto>> getOrders(@AuthenticationPrincipal PrincipalDetails principal){
+        return ApiResponse.onSuccess(orderService.getMyPageOrder(principal.getContext()));
+    }
 }

--- a/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
+++ b/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
@@ -24,12 +24,12 @@ public class OrderController {
     @PostMapping
     public ApiResponse<String> createOrders(@AuthenticationPrincipal PrincipalDetails principal,
                                                           @RequestBody OrderRequest request){
-        orderService.makeOrder(principal.getContext(), request);
+        orderService.makeOrder(principal.getContext().getEmail(), request);
         return ApiResponse.onSuccess("주문 생성이 완료되었습니다.");
     }
 
     @GetMapping
     public ApiResponse<List<MyPageOrderResponseDto>> getOrders(@AuthenticationPrincipal PrincipalDetails principal){
-        return ApiResponse.onSuccess(orderService.getMyPageOrder(principal.getContext()));
+        return ApiResponse.onSuccess(orderService.getMyPageOrder(principal.getContext().getEmail()));
     }
 }

--- a/server/src/main/java/com/onetool/server/api/order/dto/request/OrderRequest.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/request/OrderRequest.java
@@ -1,8 +1,11 @@
 package com.onetool.server.api.order.dto.request;
 
-import java.util.List;
+import lombok.Builder;
 
+import java.util.List;
+import java.util.Set;
+
+@Builder
 public record OrderRequest(
-        Long totalPrice,
-        List<OrderItem> orderList
+        Set<Long> blueprintIds
 ) {}

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
@@ -2,6 +2,13 @@ package com.onetool.server.api.order.repository;
 
 import com.onetool.server.api.order.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Orders, Long> {
+
+    @Query("SELECT o FROM Orders o JOIN FETCH o.member m WHERE m.id = :userId")
+    List<Orders> findByUserId(@Param("userId") Long userId);
 }

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
@@ -37,8 +37,8 @@ public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public Orders makeOrder(MemberAuthContext user, OrderRequest request) {
-        Member member = findMember(user.getEmail());
+    public Orders makeOrder(String userEmail, OrderRequest request) {
+        Member member = findMember(userEmail);
         return createOrders(request, member);
     }
 
@@ -85,8 +85,8 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Transactional
-    public List<OrderResponse.MyPageOrderResponseDto> getMyPageOrder(MemberAuthContext user) {
-        Member member = findMember(user.getEmail());
+    public List<OrderResponse.MyPageOrderResponseDto> getMyPageOrder(String userEmail) {
+        Member member = findMember(userEmail);
         List<Orders> ordersList = findOrdersByMemberId(member.getId());
         return OrderResponse.MyPageOrderResponseDto.from(ordersList);
     }

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
@@ -2,50 +2,96 @@ package com.onetool.server.api.order.service;
 
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.blueprint.repository.BlueprintRepository;
+import com.onetool.server.api.order.OrderBlueprint;
+import com.onetool.server.api.order.Orders;
 import com.onetool.server.api.order.dto.request.OrderItem;
 import com.onetool.server.api.order.dto.request.OrderRequest;
 import com.onetool.server.api.order.dto.response.OrderResponse;
+import com.onetool.server.api.order.repository.OrderRepository;
+import com.onetool.server.api.payments.dto.DepositResponse;
+import com.onetool.server.api.payments.repository.DepositRepository;
 import com.onetool.server.global.auth.MemberAuthContext;
 import com.onetool.server.global.exception.BaseException;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.repository.MemberRepository;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.query.Order;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static com.onetool.server.global.exception.codes.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class OrderServiceImpl implements OrderService{
+public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final BlueprintRepository blueprintRepository;
+    private final OrderRepository orderRepository;
 
-    public OrderResponse.OrderPageMemberResponseDto getMemberInfoForOrder(MemberAuthContext user, OrderRequest request){
-
+    @Transactional
+    public Orders makeOrder(MemberAuthContext user, OrderRequest request) {
         Member member = findMember(user.getEmail());
-        List<Blueprint> blueprints = new ArrayList<>();
-        for(OrderItem blueprintId : request.orderList()){
-            blueprints.add(getDiabetes(blueprintId.foodId()));
-        }
-        return OrderResponse.OrderPageMemberResponseDto
-                .orderPage(request.totalPrice(), member, blueprints);
+        return createOrders(request, member);
     }
 
+    private Orders createOrders(OrderRequest request, Member member) {
+        List<Blueprint> blueprints = getBlueprintsByIds(request.blueprintIds());
+        Orders orders = Orders.builder()
+                .totalPrice(calcTotalPrice(blueprints))
+                .member(member)
+                .totalCount(request.blueprintIds().size())
+                .build();
+        orders.setOrderItems(createOrderBlueprints(blueprints, orders));
+        return orderRepository.save(orders);
+    }
 
-    private Member findMember(String email){
+    private List<Blueprint> getBlueprintsByIds(Set<Long> blueprintIds) {
+        List<Blueprint> blueprints = new ArrayList<>();
+        blueprintIds.forEach(blueprintId ->
+                blueprints.add(
+                        blueprintRepository.findById(blueprintId).orElseThrow())
+        );
+        return blueprints;
+    }
+
+    private List<OrderBlueprint> createOrderBlueprints(List<Blueprint> blueprints, Orders orders) {
+        List<OrderBlueprint> orderBlueprints = new ArrayList<>();
+        blueprints.forEach(blueprint ->
+            orderBlueprints.add(
+                    OrderBlueprint.builder()
+                            .blueprint(blueprint)
+                            .order(orders)
+                            .build()
+            )
+        );
+        return orderBlueprints;
+    }
+
+    private Member findMember(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new BaseException(NON_EXIST_USER));
     }
 
-    public Blueprint getDiabetes(Long foodId) {
-        return blueprintRepository
-                .findById(foodId)
-                .orElseThrow(() -> new BaseException(NO_BLUEPRINT_FOUND));
+    private Long calcTotalPrice(List<Blueprint> blueprints) {
+        return blueprints.stream().mapToLong(Blueprint::getStandardPrice).sum();
+    }
+
+    @Transactional
+    public List<OrderResponse.MyPageOrderResponseDto> getMyPageOrder(MemberAuthContext user) {
+        Member member = findMember(user.getEmail());
+        List<Orders> ordersList = findOrdersByMemberId(member.getId());
+        return OrderResponse.MyPageOrderResponseDto.from(ordersList);
+    }
+
+    private List<Orders> findOrdersByMemberId(Long memberId) {
+        return new ArrayList<>(orderRepository.findByUserId(memberId));
     }
 }

--- a/server/src/main/java/com/onetool/server/api/payments/TossPayments.java
+++ b/server/src/main/java/com/onetool/server/api/payments/TossPayments.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Payments extends BaseEntity {
+public class TossPayments extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/server/src/main/java/com/onetool/server/api/payments/controller/DepositController.java
+++ b/server/src/main/java/com/onetool/server/api/payments/controller/DepositController.java
@@ -1,0 +1,35 @@
+package com.onetool.server.api.payments.controller;
+
+import com.onetool.server.api.payments.dto.DepositRequest;
+import com.onetool.server.api.payments.dto.DepositResponse;
+import com.onetool.server.api.payments.service.DepositService;
+import com.onetool.server.global.auth.login.PrincipalDetails;
+import com.onetool.server.global.exception.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/payments")
+public class DepositController {
+
+    private final DepositService depositService;
+
+    @PostMapping("/deposit")
+    public ApiResponse<?> createPayment(@RequestBody DepositRequest request) {
+        depositService.createDeposit(request);
+        return ApiResponse.onSuccess("결제 항목 추가가 완료되었습니다.");
+    }
+
+    @GetMapping("/deposit")
+    public ApiResponse<?> getPayment(
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Long userId = principalDetails.getContext().getId();
+        List<DepositResponse> responses = depositService.getDeposits(userId);
+        return ApiResponse.onSuccess(responses);
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/payments/controller/TossPaymentController.java
+++ b/server/src/main/java/com/onetool/server/api/payments/controller/TossPaymentController.java
@@ -2,10 +2,8 @@ package com.onetool.server.api.payments.controller;
 
 import com.onetool.server.api.payments.domain.PaymentProperties;
 import com.onetool.server.api.payments.dto.PaymentErrorResponse;
-import com.onetool.server.api.payments.domain.TossPaymentMethod;
 import com.onetool.server.api.payments.dto.SaveAmountRequest;
-import com.onetool.server.api.payments.repository.PaymentRepository;
-import com.onetool.server.api.payments.service.PaymentService;
+import com.onetool.server.api.payments.service.TossPaymentService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
@@ -31,14 +29,14 @@ import java.util.Base64;
 
 @Slf4j
 @RestController
-public class PaymentController {
+public class TossPaymentController {
 
     private final PaymentProperties properties;
-    private final PaymentService paymentService;
+    private final TossPaymentService tossPaymentService;
 
-    public PaymentController(PaymentProperties properties, PaymentService paymentService) {
+    public TossPaymentController(PaymentProperties properties, TossPaymentService tossPaymentService) {
         this.properties = properties;
-        this.paymentService = paymentService;
+        this.tossPaymentService = tossPaymentService;
     }
 
     @PostMapping("/saveAmount")
@@ -65,7 +63,7 @@ public class PaymentController {
         JSONParser parser = new JSONParser();
         String authorizationHeader = createAuthorizationHeader();
         JSONObject response = sendPaymentConfirmation(requestData, authorizationHeader, parser);
-        paymentService.savePayment(response);
+        tossPaymentService.savePayment(response);
         return ResponseEntity.ok().body(response);
     }
 

--- a/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
@@ -8,8 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Set;
-
 @Getter
 @Entity
 @NoArgsConstructor
@@ -24,6 +22,9 @@ public class Payment extends BaseEntity {
     private String accountNumber;
     private String bankName;
     private Long totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status;
 
 //    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
 //    @JoinColumn(name = "payment_blueprint_id")

--- a/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
@@ -1,0 +1,35 @@
+package com.onetool.server.api.payments.domain;
+
+import com.onetool.server.api.order.Orders;
+import com.onetool.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Payment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String accountName;
+    private String accountNumber;
+    private String bankName;
+    private Long totalPrice;
+
+//    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+//    @JoinColumn(name = "payment_blueprint_id")
+//    private Set<PaymentBlueprint> numbers;
+
+    @OneToOne
+    @JoinColumn(name = "orders_id")
+    private Orders orders;
+}

--- a/server/src/main/java/com/onetool/server/api/payments/domain/PaymentBlueprint.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/PaymentBlueprint.java
@@ -1,0 +1,23 @@
+package com.onetool.server.api.payments.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PaymentBlueprint {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long blueprint_id;
+}

--- a/server/src/main/java/com/onetool/server/api/payments/domain/PaymentStatus.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/PaymentStatus.java
@@ -1,0 +1,22 @@
+package com.onetool.server.api.payments.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public enum PaymentStatus {
+    PAY_PENDING("결제대기"),
+    PAY_DONE("결제완료"),
+    REFUND_PENDING("환불대기"),
+    REFUND_DONE("환불완료");
+    
+    private String value;
+
+    PaymentStatus(String value) {
+        this.value = value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/payments/dto/DepositRequest.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/DepositRequest.java
@@ -1,0 +1,16 @@
+package com.onetool.server.api.payments.dto;
+
+import lombok.Builder;
+
+import java.util.Set;
+
+@Builder
+public record DepositRequest(
+        String accountName,
+        String accountNumber,
+        String bankName,
+        Long totalPrice,
+        Set<Long> blueprintIds
+) {
+
+}

--- a/server/src/main/java/com/onetool/server/api/payments/dto/DepositResponse.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/DepositResponse.java
@@ -1,0 +1,17 @@
+package com.onetool.server.api.payments.dto;
+
+import lombok.Builder;
+
+import java.util.Set;
+
+@Builder
+public record DepositResponse(
+        Long id,
+        String accountName,
+        String accountNumber,
+        String bankName,
+        Long totalPrice,
+        Set<Long> blueprintIds
+) {
+
+}

--- a/server/src/main/java/com/onetool/server/api/payments/repository/DepositRepository.java
+++ b/server/src/main/java/com/onetool/server/api/payments/repository/DepositRepository.java
@@ -1,0 +1,17 @@
+package com.onetool.server.api.payments.repository;
+
+import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.payments.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DepositRepository extends JpaRepository<Payment, Long> {
+
+    @Query("SELECT p FROM Payment p WHERE p.orders = :orders")
+    Payment findPByOrders(@Param("orders") Orders orders);
+}

--- a/server/src/main/java/com/onetool/server/api/payments/repository/TossPaymentRepository.java
+++ b/server/src/main/java/com/onetool/server/api/payments/repository/TossPaymentRepository.java
@@ -3,5 +3,5 @@ package com.onetool.server.api.payments.repository;
 import com.onetool.server.api.payments.domain.TossPayment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PaymentRepository extends JpaRepository<TossPayment, Long> {
+public interface TossPaymentRepository extends JpaRepository<TossPayment, Long> {
 }

--- a/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
+++ b/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
@@ -1,0 +1,87 @@
+package com.onetool.server.api.payments.service;
+
+import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.repository.OrderRepository;
+import com.onetool.server.api.payments.domain.Payment;
+import com.onetool.server.api.payments.domain.PaymentBlueprint;
+import com.onetool.server.api.payments.dto.DepositRequest;
+import com.onetool.server.api.payments.dto.DepositResponse;
+import com.onetool.server.api.payments.repository.DepositRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class DepositService {
+
+    private final DepositRepository depositRepository;
+    private final OrderRepository orderRepository;
+
+    public List<DepositResponse> getDeposits(Long userId) {
+        List<Orders> ordersList = orderRepository.findByUserId(userId);
+        List<Payment> paymentList = getPaymentsByOredes(ordersList);
+        return createDepositResponseWithPayment(paymentList);
+    }
+
+    private List<Payment> getPaymentsByOredes(List<Orders> ordersList) {
+        List<Payment> payments = new ArrayList<>();
+        ordersList.forEach(order -> {
+            payments.add(
+                    depositRepository.findPByOrders(order));
+        });
+        return payments;
+    }
+
+    private List<DepositResponse> createDepositResponseWithPayment(List<Payment> paymentList) {
+        List<DepositResponse> responses = new ArrayList<>();
+        paymentList.forEach(payment -> {
+            responses.add(
+                    DepositResponse.builder()
+                            .accountName(payment.getAccountName())
+                            .accountNumber(payment.getAccountNumber())
+                            .blueprintIds(getOrdersBlueprintIds(payment.getOrders()))
+                            .bankName(payment.getBankName())
+                            .totalPrice(payment.getTotalPrice())
+                            .build());
+        });
+        return responses;
+    }
+
+    private Set<Long> getOrdersBlueprintIds(Orders orders) {
+        Set<Long> blueprintIds = new HashSet<>();
+        orders.getOrderItems().forEach((orderItem) -> {
+            blueprintIds.add(orderItem.getBlueprint().getId());
+        });
+        return blueprintIds;
+    }
+
+    @Transactional
+    public void createDeposit(DepositRequest request) {
+        Payment payment = buildPayment(request);
+        depositRepository.save(payment);
+    }
+
+    private Set<PaymentBlueprint> mapToPaymentBlueprints(Set<Long> blueprintIds) {
+        return blueprintIds.stream()
+                .map(blueprintId -> PaymentBlueprint.builder()
+                        .blueprint_id(blueprintId)
+                        .build())
+                .collect(Collectors.toSet());
+    }
+
+    private Payment buildPayment(DepositRequest request) {
+        return Payment.builder()
+                .accountNumber(request.accountNumber())
+                .accountName(request.accountName())
+                .bankName(request.bankName())
+                .totalPrice(request.totalPrice())
+                .build();
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/payments/service/TossPaymentService.java
+++ b/server/src/main/java/com/onetool/server/api/payments/service/TossPaymentService.java
@@ -1,11 +1,9 @@
 package com.onetool.server.api.payments.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.onetool.server.api.payments.domain.TossPayment;
 import com.onetool.server.api.payments.domain.TossPaymentMethod;
 import com.onetool.server.api.payments.domain.TossPaymentStatus;
-import com.onetool.server.api.payments.repository.PaymentRepository;
+import com.onetool.server.api.payments.repository.TossPaymentRepository;
 import org.json.simple.JSONObject;
 import org.springframework.stereotype.Service;
 
@@ -13,12 +11,12 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Service
-public class PaymentService {
+public class TossPaymentService {
 
-    private final PaymentRepository paymentRepository;
+    private final TossPaymentRepository tossPaymentRepository;
 
-    public PaymentService(PaymentRepository paymentRepository) {
-        this.paymentRepository = paymentRepository;
+    public TossPaymentService(TossPaymentRepository tossPaymentRepository) {
+        this.tossPaymentRepository = tossPaymentRepository;
     }
 
     public void savePayment(JSONObject response) {
@@ -42,6 +40,6 @@ public class PaymentService {
                 .totalAmount(totalAmount)
                 .build();
 
-        paymentRepository.save(tossPayment);
+        tossPaymentRepository.save(tossPayment);
     }
 }

--- a/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
+++ b/server/src/main/java/com/onetool/server/global/handler/ExceptionAdvice.java
@@ -92,13 +92,14 @@ public class ExceptionAdvice {
      * @param generalException
      * @return
      */
-//    @ExceptionHandler(BaseException.class)
-//    public ResponseEntity<Object> onThrowException(BaseException generalException) {
-//        log.error("BaseException", generalException);
-//        Reason.ReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
-//        ApiResponse<?> baseResponse = ApiResponse.onFailure(errorReasonHttpStatus.getCode(), errorReasonHttpStatus.getMessage(), null);
-//        return handleExceptionInternal(baseResponse);
-//    }
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<Object> onThrowException(BaseException generalException) {
+        log.error(generalException.getMessage());
+        log.error("BaseException", generalException);
+        Reason.ReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        ApiResponse<?> baseResponse = ApiResponse.onFailure(errorReasonHttpStatus.getCode(), errorReasonHttpStatus.getMessage(), null);
+        return handleExceptionInternal(baseResponse);
+    }
 
     /**
      * [Exception] API 호출 시 'Header' 내에 데이터 값이 유효하지 않은 경우

--- a/server/src/test/java/com/onetool/server/api/order/service/OrderServiceImplTest.java
+++ b/server/src/test/java/com/onetool/server/api/order/service/OrderServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.onetool.server.api.order.service;
+
+import com.onetool.server.api.order.dto.request.OrderRequest;
+import com.onetool.server.api.order.dto.response.OrderResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles({"test"})
+class OrderServiceImplTest {
+
+    private final static String ADMIN_EMAIL = "admin@example.com";
+
+    @Autowired
+    private OrderServiceImpl orderServiceImpl;
+
+    @Test
+    @DisplayName("주문 생성")
+    void createOrderTest() {
+        OrderRequest orderRequest = new OrderRequest(
+                new HashSet<>(List.of(1L, 2L, 3L))
+        );
+        orderServiceImpl.makeOrder(ADMIN_EMAIL, orderRequest);
+
+        List<OrderResponse. MyPageOrderResponseDto> response
+                = orderServiceImpl.getMyPageOrder(ADMIN_EMAIL);
+
+        assertThat(response.size()).isEqualTo(1);
+    }
+}

--- a/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceMockTest.java
+++ b/server/src/test/java/com/onetool/server/blueprint/BlueprintServiceMockTest.java
@@ -134,7 +134,8 @@ public class BlueprintServiceMockTest {
                 LocalDateTime.now().plusDays(10),
                 "윤성원 작가",
                 "https://onetool.com/download",
-                false
+                false,
+                "detailImage URL"
         );
 
         // When
@@ -189,7 +190,8 @@ public class BlueprintServiceMockTest {
                 LocalDateTime.now().plusDays(10),
                 "윤성원 작가",
                 "https://onetool.com/download",
-                false
+                false,
+                "detailImage URL"
         );
 
         String accessToken = obtainAccessToken("admin@example.com", "1234");


### PR DESCRIPTION
## #️⃣ 이슈

- close #157 

## 🔎 작업 내용

기존에 작성된 주문과 결제 엔티티를 싹 다 바꾸느라 시간이 결렸습니다..
새롭게 작성한 엔티티는 아래와 같습니다.

<img width="973" alt="image" src="https://github.com/user-attachments/assets/495f2900-2375-413d-8b33-70cbbe14802a" />

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
### 결제 상태(status)는 어떻게 관리되어야 하는가?
현재 `Payment`에서 Status를 관리하고 있습니다. 만약 Payment에서 이를 관리할 경우, **주문 내역 조회 시 주문에 대한 결제를 모두 조회해야하는 상황이 발생**합니다. 고작 상태 칼럼 하나만 조회하기엔 Select 두 번이 매우 비효율적이라고 판단했습니다.
만약 `Orders`에서 status를 관리하면 어떻게 될까요? 이 또한 마찬가지로 결제 확인 후, **status를 update하려면 Payment와 Orders를 Join해야 합니다.**

**저는 Orders에서 관리되는 것이 더 좋다고 생각합니다.** 왜냐하면 Payment에서 관리될 경우 마이페이지 조회 시마다 두 번의 Select가 발생하기 때문입니다. 그러나 update의 경우, 보통 한 번만 이루어지기 때문에 훨씬 효율적이라고 생각되네요!

다른 분들의 생각은 어떨지 궁금합니다.


## 🧲 참고 자료 및 공유 사항


