### PR TITLE
fix(payment): 결제 생성 시 orderId를 Request로 받도록 수정

### DIFF
--- a/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
+++ b/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
@@ -22,10 +22,10 @@ public class OrderController {
     private final OrderServiceImpl orderService;
 
     @PostMapping
-    public ApiResponse<String> createOrders(@AuthenticationPrincipal PrincipalDetails principal,
+    public ApiResponse<Long> createOrders(@AuthenticationPrincipal PrincipalDetails principal,
                                                           @RequestBody OrderRequest request){
-        orderService.makeOrder(principal.getContext().getEmail(), request);
-        return ApiResponse.onSuccess("주문 생성이 완료되었습니다.");
+        Long orderId = orderService.makeOrder(principal.getContext().getEmail(), request);
+        return ApiResponse.onSuccess(orderId);
     }
 
     @GetMapping

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
@@ -10,6 +10,7 @@ import com.onetool.server.api.order.dto.response.OrderResponse;
 import com.onetool.server.api.order.repository.OrderRepository;
 import com.onetool.server.api.payments.dto.DepositResponse;
 import com.onetool.server.api.payments.repository.DepositRepository;
+import com.onetool.server.api.payments.service.DepositService;
 import com.onetool.server.global.auth.MemberAuthContext;
 import com.onetool.server.global.exception.BaseException;
 import com.onetool.server.api.member.domain.Member;
@@ -35,11 +36,13 @@ public class OrderServiceImpl implements OrderService {
     private final MemberRepository memberRepository;
     private final BlueprintRepository blueprintRepository;
     private final OrderRepository orderRepository;
+    private final DepositService depositService;
 
     @Transactional
-    public Orders makeOrder(String userEmail, OrderRequest request) {
+    public Long makeOrder(String userEmail, OrderRequest request) {
         Member member = findMember(userEmail);
-        return createOrders(request, member);
+        Orders orders = createOrders(request, member);
+        return orders.getId();
     }
 
     private Orders createOrders(OrderRequest request, Member member) {

--- a/server/src/main/java/com/onetool/server/api/payments/dto/DepositRequest.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/DepositRequest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 @Builder
 public record DepositRequest(
+        Long orderId,
         String accountName,
         String accountNumber,
         String bankName,

--- a/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
+++ b/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
@@ -8,6 +8,7 @@ import com.onetool.server.api.payments.dto.DepositRequest;
 import com.onetool.server.api.payments.dto.DepositResponse;
 import com.onetool.server.api.payments.repository.DepositRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class DepositService {
@@ -27,6 +29,7 @@ public class DepositService {
     public List<DepositResponse> getDeposits(Long userId) {
         List<Orders> ordersList = orderRepository.findByUserId(userId);
         List<Payment> paymentList = getPaymentsByOredes(ordersList);
+        log.info("paymentList size: {}", paymentList.size());
         return createDepositResponseWithPayment(paymentList);
     }
 
@@ -44,6 +47,7 @@ public class DepositService {
         paymentList.forEach(payment -> {
             responses.add(
                     DepositResponse.builder()
+                            .id(payment.getId())
                             .accountName(payment.getAccountName())
                             .accountNumber(payment.getAccountNumber())
                             .blueprintIds(getOrdersBlueprintIds(payment.getOrders()))
@@ -82,6 +86,11 @@ public class DepositService {
                 .accountName(request.accountName())
                 .bankName(request.bankName())
                 .totalPrice(request.totalPrice())
+                .orders(findOrders(request.orderId()))
                 .build();
+    }
+
+    private Orders findOrders(Long orderId) {
+        return orderRepository.findById(orderId).orElseThrow();
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #157 

## 🔎 작업 내용

주문과 결제 정보를 모두 담아서 사용하기에 필드가 너무 많아지고, 복잡해지는 문제가 발생했습니다.
이를 해결하기 위해 주문과 결제에 대한 API를 따로 만들었으나, 결제와 주문의 연관관계를 맺는데 어려움이 있습니다.
주문 생성과 결제 생성이 개별적인 API이기 때문에, 결제 생성 시 주문의 FK를 설정하기 위해 생성한 주문 ID가 필요합니다.

결제하기(주문하기) 버튼 클릭
주문 생성 API 호출
주문 생성 API의 응답으로 주문 ID 반환
결제 생성 API 호출 (body에 주문 ID 첨부)


## 🤔 고민해볼 부분 & 코드 리뷰 희망사항



## 🧲 참고 자료 및 공유 사항


