### PR TITLE
fix(payment, order): 예외 처리

### DIFF
--- a/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
+++ b/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
@@ -5,6 +5,7 @@ import com.onetool.server.api.order.dto.request.OrderRequest;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
 import com.onetool.server.api.order.service.OrderServiceImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +24,7 @@ public class OrderController {
 
     @PostMapping
     public ApiResponse<Long> createOrders(@AuthenticationPrincipal PrincipalDetails principal,
-                                                          @RequestBody OrderRequest request){
+                                                         @Valid @RequestBody OrderRequest request){
         Long orderId = orderService.makeOrder(principal.getContext().getEmail(), request);
         return ApiResponse.onSuccess(orderId);
     }

--- a/server/src/main/java/com/onetool/server/api/order/dto/request/OrderRequest.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/request/OrderRequest.java
@@ -1,5 +1,6 @@
 package com.onetool.server.api.order.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 
 import java.util.List;
@@ -7,5 +8,6 @@ import java.util.Set;
 
 @Builder
 public record OrderRequest(
+        @NotEmpty
         Set<Long> blueprintIds
 ) {}

--- a/server/src/main/java/com/onetool/server/api/payments/dto/DepositResponse.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/DepositResponse.java
@@ -10,8 +10,7 @@ public record DepositResponse(
         String accountName,
         String accountNumber,
         String bankName,
-        Long totalPrice,
-        Set<Long> blueprintIds
+        Long totalPrice
 ) {
 
 }

--- a/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
+++ b/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
@@ -15,10 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -52,7 +49,6 @@ public class DepositService {
                             .id(payment.getId())
                             .accountName(payment.getAccountName())
                             .accountNumber(payment.getAccountNumber())
-                            .blueprintIds(getOrdersBlueprintIds(payment.getOrders()))
                             .bankName(payment.getBankName())
                             .totalPrice(payment.getTotalPrice())
                             .build());
@@ -60,26 +56,10 @@ public class DepositService {
         return responses;
     }
 
-    private Set<Long> getOrdersBlueprintIds(Orders orders) {
-        Set<Long> blueprintIds = new HashSet<>();
-        orders.getOrderItems().forEach((orderItem) -> {
-            blueprintIds.add(orderItem.getBlueprint().getId());
-        });
-        return blueprintIds;
-    }
-
     @Transactional
     public void createDeposit(DepositRequest request) {
         Payment payment = buildPayment(request);
         depositRepository.save(payment);
-    }
-
-    private Set<PaymentBlueprint> mapToPaymentBlueprints(Set<Long> blueprintIds) {
-        return blueprintIds.stream()
-                .map(blueprintId -> PaymentBlueprint.builder()
-                        .blueprint_id(blueprintId)
-                        .build())
-                .collect(Collectors.toSet());
     }
 
     private Payment buildPayment(DepositRequest request) {

--- a/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
+++ b/server/src/main/java/com/onetool/server/api/payments/service/DepositService.java
@@ -7,6 +7,8 @@ import com.onetool.server.api.payments.domain.PaymentBlueprint;
 import com.onetool.server.api.payments.dto.DepositRequest;
 import com.onetool.server.api.payments.dto.DepositResponse;
 import com.onetool.server.api.payments.repository.DepositRepository;
+import com.onetool.server.global.exception.BaseException;
+import com.onetool.server.global.exception.codes.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -91,6 +93,6 @@ public class DepositService {
     }
 
     private Orders findOrders(Long orderId) {
-        return orderRepository.findById(orderId).orElseThrow();
+        return orderRepository.findById(orderId).orElseThrow(() -> new BaseException(ErrorCode.ORDER_NOT_FOUND));
     }
 }

--- a/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/exception/codes/ErrorCode.java
@@ -89,9 +89,9 @@ public enum ErrorCode implements BaseCode {
     NO_QNA_CONTENT(HttpStatus.NO_CONTENT, "QNA-0000", "게시된 문의사항이 없습니다."),
     UNAVAILABLE_TO_MODIFY(HttpStatus.FORBIDDEN, "QNA-0001", "게시글에 대한 권한이 없습니다."),
     NO_QNA_REPLY(HttpStatus.NO_CONTENT, "QNA-0002", "유효한 댓글이 아닙니다."),
-    /*
-    *
-    * */
+
+    //결제 및 주문 에러
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER-001", "주문이 존재하지 않습니다."),
 
     // 5xx : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER-0000", "서버 에러");


### PR DESCRIPTION
## #️⃣ 이슈

- close #160 

## 🔎 작업 내용

- 주문하려는 도면이 없는 경우 예외 발생
- Set 컬렉션을 통한 주문하려는 도면 중복되는 문제 해결
- Payment의 orderId가 존재하지 않는 주문일 경우 예외 발생
- 결제 생성 시, blueprintId를 입력받지 않도록 수정

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

@Valid를 사용하여 DTO의 유효성 검사를 하도록 구현했습니다.
결제 상태에 대해 추가적인 수정이 필요해보여요.

## 🧲 참고 자료 및 공유 사항


