### PR TITLE
 feat(order): 주문 상태 및 다운로드 URL 활성화 구현

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/controller/MemberController.java
+++ b/server/src/main/java/com/onetool/server/api/member/controller/MemberController.java
@@ -13,15 +13,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.web.server.Cookie;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.List;
 
@@ -87,7 +82,6 @@ public class MemberController {
         if (principalDetails == null) {
             throw new MemberNotFoundException(ErrorCode.NON_EXIST_USER);
         }
-
 
         Long id = principalDetails.getContext().getId();
         memberService.deleteMember(id);

--- a/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
@@ -21,7 +21,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -171,7 +170,6 @@ public class MemberService {
     @Transactional
     public void deleteMember(Long id) {
         Member member = memberRepository.findById(id).orElseThrow();
-
         memberRepository.delete(member);
     }
 

--- a/server/src/main/java/com/onetool/server/api/order/OrderBlueprint.java
+++ b/server/src/main/java/com/onetool/server/api/order/OrderBlueprint.java
@@ -16,7 +16,6 @@ public class OrderBlueprint extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //도면관련 매핑은 좀 이따가
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "blueprint_id")
     private Blueprint blueprint;
@@ -25,5 +24,5 @@ public class OrderBlueprint extends BaseEntity {
     @JoinColumn(name = "orders_id")
     private Orders order;
 
-
+    private String downloadUrl;
 }

--- a/server/src/main/java/com/onetool/server/api/order/Orders.java
+++ b/server/src/main/java/com/onetool/server/api/order/Orders.java
@@ -2,11 +2,14 @@ package com.onetool.server.api.order;
 
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.payments.domain.Payment;
+import com.onetool.server.api.payments.domain.PaymentStatus;
 import com.onetool.server.global.entity.BaseEntity;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.payments.TossPayments;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +19,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
 public class Orders extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,6 +28,10 @@ public class Orders extends BaseEntity {
     private Long totalPrice;
 
     private int totalCount;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'PAY_PENDING'")
+    private PaymentStatus status;
 
     @Setter
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
@@ -38,9 +46,13 @@ public class Orders extends BaseEntity {
 
     public List<String> getOrderItemsDownloadLinks() {
         List<String> orderItemsDownloadLinks = new ArrayList<>();
-        this.orderItems.forEach(orderBlueprint ->
-                orderItemsDownloadLinks.add(
-                        orderBlueprint.getDownloadUrl()));
+        if(this.getStatus() == PaymentStatus.PAY_DONE) {
+            this.orderItems.forEach(orderBlueprint ->
+                    orderItemsDownloadLinks.add(
+                            orderBlueprint.getDownloadUrl())
+
+            );
+        }
         return orderItemsDownloadLinks;
     }
 }

--- a/server/src/main/java/com/onetool/server/api/order/Orders.java
+++ b/server/src/main/java/com/onetool/server/api/order/Orders.java
@@ -35,4 +35,12 @@ public class Orders extends BaseEntity {
 
     @OneToOne(mappedBy = "orders")
     private Payment payment;
+
+    public List<String> getOrderItemsDownloadLinks() {
+        List<String> orderItemsDownloadLinks = new ArrayList<>();
+        this.orderItems.forEach(orderBlueprint ->
+                orderItemsDownloadLinks.add(
+                        orderBlueprint.getDownloadUrl()));
+        return orderItemsDownloadLinks;
+    }
 }

--- a/server/src/main/java/com/onetool/server/api/order/dto/response/OrderResponse.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/response/OrderResponse.java
@@ -20,7 +20,8 @@ public class OrderResponse {
             String orderName,
             Long orderId,
             Long totalPrice,
-            String status
+            String status,
+            List<String> downloadUrl
     ){
         public static List<MyPageOrderResponseDto> from(List<Orders> ordersList){
             List<MyPageOrderResponseDto> dtos = new ArrayList<>();
@@ -34,6 +35,7 @@ public class OrderResponse {
                                 .orderId(orders.getId())
                                 .orderName(createOrderName(orders))
                                 .totalPrice(orders.getTotalPrice())
+                                .downloadUrl(orders.getOrderItemsDownloadLinks())
                                 .build()
                 );
             });

--- a/server/src/main/java/com/onetool/server/api/order/dto/response/OrderResponse.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/response/OrderResponse.java
@@ -36,6 +36,7 @@ public class OrderResponse {
                                 .orderName(createOrderName(orders))
                                 .totalPrice(orders.getTotalPrice())
                                 .downloadUrl(orders.getOrderItemsDownloadLinks())
+                                .status(orders.getStatus().name())
                                 .build()
                 );
             });

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderServiceImpl.java
@@ -72,6 +72,7 @@ public class OrderServiceImpl implements OrderService {
                     OrderBlueprint.builder()
                             .blueprint(blueprint)
                             .order(orders)
+                            .downloadUrl(blueprint.getDownloadLink())
                             .build()
             )
         );

--- a/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
@@ -23,9 +23,6 @@ public class Payment extends BaseEntity {
     private String bankName;
     private Long totalPrice;
 
-    @Enumerated(EnumType.STRING)
-    private PaymentStatus status;
-
 //    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
 //    @JoinColumn(name = "payment_blueprint_id")
 //    private Set<PaymentBlueprint> numbers;

--- a/server/src/main/java/com/onetool/server/api/payments/domain/PaymentStatus.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/PaymentStatus.java
@@ -1,15 +1,15 @@
 package com.onetool.server.api.payments.domain;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 public enum PaymentStatus {
+    PAY_CANCEL("결제취소"),
     PAY_PENDING("결제대기"),
     PAY_DONE("결제완료"),
     REFUND_PENDING("환불대기"),
     REFUND_DONE("환불완료");
-    
+
     private String value;
 
     PaymentStatus(String value) {


### PR DESCRIPTION
## #️⃣ 이슈

- close #166 

## 🔎 작업 내용

- 기존 결제 엔티티에 있던 결제 상태를 주문 엔티티로 이동
- 결제 상태에 결제 취소 추가
- 결제 상태가 `결제완료`인 주문에 대해서만 제대로된 다운로드 링크 반환

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항



## 🧲 참고 자료 및 공유 사항


