### PR TITLE
feat(member): 비밀번호 변경되지 않던 문제 해결

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/dto/MemberUpdateRequest.java
+++ b/server/src/main/java/com/onetool/server/api/member/dto/MemberUpdateRequest.java
@@ -11,7 +11,6 @@ public class MemberUpdateRequest {
     private String name;
     private String phoneNum;
     private String developmentField;
-    private String currentPassword;
     private String newPassword;
 
     @Builder
@@ -20,7 +19,6 @@ public class MemberUpdateRequest {
         this.name = name;
         this.phoneNum = phoneNum;
         this.developmentField = developmentField;
-        this.currentPassword = currentPassword;
         this.newPassword = newPassword;
     }
 }

--- a/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
@@ -78,6 +78,7 @@ public class MemberService {
         log.info(member.toString());
 
         if (!encoder.matches(password, member.getPassword())) {
+            log.error("비밀번호 불일치: "+ encoder.encode(member.getPassword()));
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
@@ -137,7 +138,6 @@ public class MemberService {
     public boolean verifiedCode(String email, String authCode) {
         //this.checkDuplicatedEmail(email);
         String redisAuthCode = mailRedisService.getValues(AUTH_CODE_PREFIX + email);
-
         return mailRedisService.checkExistsValue(redisAuthCode) && redisAuthCode.equals(authCode);
     }
 
@@ -159,12 +159,10 @@ public class MemberService {
     }
 
     @Transactional
-    public Member updateMember(Long id, MemberUpdateRequest request) {
+    public void updateMember(Long id, MemberUpdateRequest request) {
         Member member = memberRepository.findById(id).orElseThrow();
-
-        member.updateWith(request);
-
-        return memberRepository.save(member);
+        member.updateWith(request, encoder);
+        memberRepository.save(member);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣ 이슈

- close #164 

## 🔎 작업 내용

- 비밀번호 변경 로직을 추가
- setter을 통한 유저 정보 업데이트


## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

### 더티체킹이 안되던 문제
기존 코드는 Equal을 통해 이름과 비밀번호을 변경할 경우, 비밀번호만 변경되지 않는 문제가 발생했어요.
```java
@Transactional
public void updateWith(MemberUpdateRequest request, PasswordEncoder encoder) {
        Optional.ofNullable(request.getName()).ifPresent(this.name = name);
Optional.ofNullable(request.getNewPassword()).ifPresent(newPassword -> {
            log.info("new password: {}", newPassword);
            this.password = encoder.encode(newPassword);
        });
```
비밀번호만 변경하는 경우에는 update 쿼리가 아예 실행되지 않은 것을 발견했습니다. 

이를 통해 긴 문자열 (인코딩된 비밀번호)는 equal을 통해 더티체킹이 발생하지 않는다는 것을 발견했다.
따라서, 이를 해결하기 위해 Hibernate가 더티체킹 가능하도록 `setter`을 통해 값을 변경하여 이를 해결했다.

## 🧲 참고 자료 및 공유 사항


