### PR TITLE
refactor(blueprint): 커버링 인덱스를 통한 카테고리 검색 성능 개선

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/Blueprint.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/Blueprint.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_blueprint_second_category", columnList = "categoryId, secondCategory, inspectionStatus, isDeleted, id DESC")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE Blueprint SET is_deleted = true WHERE id = ?")

--- a/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/repository/BlueprintRepository.java
@@ -42,15 +42,22 @@ public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
     """)
     List<Blueprint> findWithCartBlueprints(@Param("blueprints") List<Blueprint> blueprints);
 
-    @Query(value = "SELECT b FROM Blueprint b WHERE b.categoryId = " +
-            "(SELECT f.id FROM FirstCategory f WHERE f.name = :first) " +
-            "AND b.inspectionStatus = :status")
-    Page<Blueprint> findAllByFirstCategory(@Param("first") String category, @Param("status") InspectionStatus status, Pageable pageable);
+    @Query(value = """
+            SELECT b FROM Blueprint b WHERE b.categoryId = :first
+            AND b.inspectionStatus = :status
+            """)
+    Page<Blueprint> findAllByFirstCategory(@Param("first") Long categoryId, @Param("status") InspectionStatus status, Pageable pageable);
 
-    @Query(value = "SELECT b FROM Blueprint b WHERE b.secondCategory = :second " +
-            "AND b.categoryId = (SELECT f.id FROM FirstCategory f WHERE f.name = :first) " +
-            "AND b.inspectionStatus = :status")
-    Page<Blueprint> findAllBySecondCategory(@Param("first") String firstCategory, @Param("second") String secondCategory, @Param("status") InspectionStatus status, Pageable pageable);
+    @Query(value = """
+        SELECT b FROM Blueprint b
+        WHERE
+            b.categoryId = :first
+            AND b.secondCategory = :second
+            AND b.inspectionStatus = :status
+       """,
+            countQuery = "SELECT count(b.id) FROM Blueprint b WHERE b.inspectionStatus = :status"
+    )
+    Page<Blueprint> findAllBySecondCategory(@Param("first") Long firstCategoryId, @Param("second") String secondCategory, @Param("status") InspectionStatus status, Pageable pageable);
 
     @Query(value = "SELECT count(b) FROM Blueprint b")
     Long countAllBlueprint();

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintSearchService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintSearchService.java
@@ -61,7 +61,7 @@ public class BlueprintSearchService {
     private List<BlueprintResponse> sortBlueprintsWithCategory(Long categoryId, Pageable sortedPageable) {
         FirstCategoryType category = FirstCategoryType.findByCategoryId(categoryId);
         Page<Blueprint> blueprintPage = blueprintRepository.findAllByFirstCategory(
-                category.getType(), InspectionStatus.PASSED, sortedPageable);
+                category.getCategoryId(), InspectionStatus.PASSED, sortedPageable);
         return blueprintPage.stream()
                 .map(BlueprintResponse::from)
                 .collect(Collectors.toList());
@@ -90,7 +90,7 @@ public class BlueprintSearchService {
     }
 
     private Page<SearchResponse> findAllByFirstCategory(FirstCategoryType category, Pageable pageable) {
-        Page<Blueprint> result = blueprintRepository.findAllByFirstCategory(category.getType(), InspectionStatus.PASSED, pageable);
+        Page<Blueprint> result = blueprintRepository.findAllByFirstCategory(category.getCategoryId(), InspectionStatus.PASSED, pageable);
         List<SearchResponse> list = result.getContent().stream()
                 .map(SearchResponse::from)
                 .collect(Collectors.toList());
@@ -99,7 +99,7 @@ public class BlueprintSearchService {
 
     private Page<SearchResponse> findAllBySecondCategory(FirstCategoryType firstCategory, String secondCategory, Pageable pageable) {
         Page<Blueprint> result = blueprintRepository.findAllBySecondCategory(
-                firstCategory.getType(), secondCategory, InspectionStatus.PASSED, pageable);
+                firstCategory.getCategoryId(), secondCategory, InspectionStatus.PASSED, pageable);
         List<SearchResponse> list = result.getContent().stream()
                 .map(SearchResponse::from)
                 .collect(Collectors.toList());

--- a/server/src/main/java/com/onetool/server/data/DataLoader.java
+++ b/server/src/main/java/com/onetool/server/data/DataLoader.java
@@ -1,4 +1,4 @@
-package com.onetool.server;
+package com.onetool.server.data;
 
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.blueprint.InspectionStatus;

--- a/server/src/main/java/com/onetool/server/data/DummyDataLoader.java
+++ b/server/src/main/java/com/onetool/server/data/DummyDataLoader.java
@@ -17,7 +17,7 @@ import java.math.BigInteger;
 public class DummyDataLoader implements CommandLineRunner {
 
     private final static boolean EXECUTE_FLAG = false;
-    private final static int DUMMY_DATA_COUNT = 100_000;
+    private final static int DUMMY_DATA_COUNT = 1_000_000;
 
     private final static String[] BLUEPRINT_NAME_LIST = {"골프장 ", "당구장 ", "학교 ", "영화관 ", "도서관 ", "학교 ", "상가 ", "전시관", "역사관 ", "식당 "};
     private final static String BLUEPRINT_DETAIL = "도면에 대한 상세 정보 내역입니다.";

--- a/server/src/main/java/com/onetool/server/data/DummyDataLoader.java
+++ b/server/src/main/java/com/onetool/server/data/DummyDataLoader.java
@@ -1,0 +1,85 @@
+package com.onetool.server.data;
+
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.blueprint.InspectionStatus;
+import com.onetool.server.api.blueprint.repository.BlueprintRepository;
+import com.onetool.server.api.category.FirstCategoryRepository;
+import com.onetool.server.api.member.repository.MemberRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+
+@Profile({"local"})
+@Component
+public class DummyDataLoader implements CommandLineRunner {
+
+    private final static boolean EXECUTE_FLAG = false;
+    private final static int DUMMY_DATA_COUNT = 100_000;
+
+    private final static String[] BLUEPRINT_NAME_LIST = {"골프장 ", "당구장 ", "학교 ", "영화관 ", "도서관 ", "학교 ", "상가 ", "전시관", "역사관 ", "식당 "};
+    private final static String BLUEPRINT_DETAIL = "도면에 대한 상세 정보 내역입니다.";
+    private final static String CREATOR_NAME = "작가 ";
+    private final static Long STANDARD_PRICE = 10000L;
+    private final static Long SALE_PRICE = 10000L;
+    private final static String PROGRAM = "CAD";
+    private final static String DOWNLOAD_LINK = "https://google.com";
+    private final static String EXTENSION = ".exe";
+    private final static String BLUEPRINT_IMG = "https://s3.amazon.com/dd2gA1fgdaQ51df52134";
+    private final static BigInteger HITS = BigInteger.valueOf(0);
+    private final static InspectionStatus INSPECTION_STATUS = InspectionStatus.PASSED;
+
+    private final FirstCategoryRepository firstCategoryRepository;
+    private final BlueprintRepository blueprintRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public DummyDataLoader(FirstCategoryRepository firstCategoryRepository, BlueprintRepository blueprintRepository, MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+        this.firstCategoryRepository = firstCategoryRepository;
+        this.blueprintRepository = blueprintRepository;
+        this.memberRepository = memberRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        if(EXECUTE_FLAG) {
+            createDummyData();
+        }
+    }
+
+    private void createDummyData() {
+        for(int i = 0; i < DUMMY_DATA_COUNT; i++) {
+            createBlueprint(
+                    BLUEPRINT_NAME_LIST[i%10],
+                    CREATOR_NAME + i,
+                    (long) (i%6)
+            );
+        }
+    }
+
+    private void createBlueprint(
+            String blueprintName,
+            String creatorName,
+            Long categoryId
+    ) {
+        Blueprint blueprint = Blueprint.builder()
+                .blueprintName(blueprintName)
+                .blueprintDetails(DummyDataLoader.BLUEPRINT_DETAIL)
+                .creatorName(creatorName)
+                .standardPrice(DummyDataLoader.STANDARD_PRICE)
+                .salePrice(DummyDataLoader.SALE_PRICE)
+                .program(DummyDataLoader.PROGRAM)
+                .downloadLink(DummyDataLoader.DOWNLOAD_LINK)
+                .extension(DummyDataLoader.EXTENSION)
+                .blueprintImg(DummyDataLoader.BLUEPRINT_IMG)
+                .categoryId(categoryId)
+                .secondCategory("공공")
+                .hits(DummyDataLoader.HITS)
+                .inspectionStatus(DummyDataLoader.INSPECTION_STATUS)
+                .build();
+        blueprintRepository.save(blueprint);
+    }
+}

--- a/server/src/main/java/com/onetool/server/data/TestDataLoader.java
+++ b/server/src/main/java/com/onetool/server/data/TestDataLoader.java
@@ -1,4 +1,4 @@
-package com.onetool.server;
+package com.onetool.server.data;
 
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.blueprint.InspectionStatus;


### PR DESCRIPTION
## #️⃣ 이슈

- #178 


## 🔎 작업 내용

### Refactor
- Blueprint에 카테고리 검색 인덱스 추가
- Blueprint와 FirstCategory를 Join하는 대신 Blueprint에서 Join 키를 통해 조회하도록 수정
- 도면 더미테이스 수 1,000,000으로 증가

### Chore
- chore: DataLoader를 data 패키지로 이동

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

###  1️⃣JOIN과 Subquery의 속도 차이

> [!IMPORTANT]
> 데이터 1,000,000건을 기준으로 테스트 됐습니다. 

기존 2차 카테고리 검색 쿼리의 경우, FirstCategory를 `서브쿼리로`하여 검색한다. 일반적으로 서브쿼리보다 **Join이 비용이 더 적다**고 알고 있어 쿼리를 수정해보았다.
```sql
    @Query(value = """
        SELECT b FROM Blueprint b WHERE b.secondCategory = :second
        AND b.categoryId = (SELECT f.id FROM FirstCategory f WHERE f.name = :first)
        AND b.inspectionStatus = :status
       """)
    Page<Blueprint> findAllBySecondCategory(@Param("first") String firstCategory, @Param("second") String secondCategory, @Param("status") InspectionStatus status, Pageable pageable);
```
```sql
@Query(value = """
        SELECT b FROM Blueprint b JOIN FETCH FirstCategory f
        ON b.categoryId = f.id
        WHERE 
            b.secondCategory = :second
            AND f.name = :first
            AND b.inspectionStatus = :status
       """)
```

| 설명 | 응답시간 | 스캔 방식 |
|--------|--------|--------| 
| JOIN | 340 | Table Scan |
| SubQuery | 408 | Inner Hash Join|

> [!NOTE]
>  **결론적으로 Join이 성능적으로 더욱 우수하였다.** 그 이유는 JOIN 키(category_id)가 인덱싱되어 있지 않아, Blueprint와 FirstCategory에 대한 Table Scan을 각각 수행 후 join을 또 한번 실행하기 때문이라고 추정됩니다.


이를 더욱 성능적으로 개선하기 위해 FirestCategory를 사용(Join이나 Subquery)하는 대신 Blueprint에 있는 `JoinKey(Category_id)`를 이용하여 Blueprint만으로도 조회 가능하도록 수정했습니다.

```sql
SELECT b FROM Blueprint b
        WHERE
            b.categoryId = :first
            AND b.secondCategory = :second
            AND b.inspectionStatus = :status
```
추가적으로 해당 쿼리를 성능 향상시키고자 blueprint 내부에 인덱싱을 도입하여 이를 해결하기로 결정했습니다.

### 2️⃣인덱스 적용
먼저 2차 카테고리 검색의 경우 아래 쿼리가 수행된다.
```
    SELECT * FROM blueprint
    WHERE
        (is_deleted = 0) 
        AND category_id=? 
        AND second_category=? 
        AND inspection_status=? 
    ORDER BY id desc 
    LIMIT ?, ?

    SELECt count(id) FROM blueprint
    WHERE
        (is_deleted = 0) 
        AND category_id=? 
        AND second_category=? 
        AND inspection_status=? 
```

따라서, 커버링 인덱스를 통해 `category_id`와 `second_category`, `inspection_status`, `is_deleted`를 포함하도록 생성한 후 테스트를 진행했다.

```java
@Index(name = "idx_blueprint_second_category", columnList = "categoryId, secondCategory, inspectionStatus, isDeleted, id DESC"),
```

### 인덱스 적용 전
<img width="925" alt="Image" src="https://github.com/user-attachments/assets/2c1eda8c-4014-402c-8345-06c21a62a7f8" />

### 인덱스 적용 후

<img width="922" alt="Image" src="https://github.com/user-attachments/assets/9c49ac46-d83d-4654-8147-a2e6bd74c8e1" />

결론적으로 637ms에서 473ms로 약 `34% 향상`시킬 수 있었다.

## count 쿼리 최적화
현재 카테고리 검색의 경우, 인피니티 스크롤이 아닌 `페이지 방식`을 뷰에서 채택하고 있다. 따라서, `Slice`를 이용하여 count 쿼리를 수행시키지 않는 방법을 적용하는게 쉽지 않다. count 쿼리를 직접 지정하여 인덱스를 탈 수 있도록 제공해봤다.

### count 인덱스 생성
```java
// 인덱스
@Index(name = "idx_blueprint_count", columnList = "id, inspectionStatus, isDeleted")

// count Query
countQuery = "SELECT count(b.id) FROM Blueprint b WHERE b.inspectionStatus = :status"
```
Count 쿼리에서 사용할 수 있도록 id를 `커버링 인덱스`하여 인덱스를 지정했다.
**결론적으로 별 차이가 없었다.**

<img width="75" alt="Image" src="https://github.com/user-attachments/assets/5eb885d6-c3da-4a8b-bd29-73576395b583" />

그 이유는 간단하다. `InspectionStatus`와 `is_deleted`는 **거의 모든 데이터가 'PASSED'와 false로 지정되어 있어** 인덱스를 사용해도 극적인 성능 개선이 보이지 않는다. 오히려 인덱스 생성으로 인한 저장 리소스 소모가 있다고 판단했다. **따라서, countQuery에 대한 별도의 인덱싱은 수행하지 않기로 결정했다.**

### 3️⃣결론
1. 카테고리 검색에서 사용할 수 있도록 커버링 인덱스를 도입했다.
2. Pageable 사용 시 발생하는 `countQuery`는 불가피하게 사용해야 한다.
3. `countQuery`에 대한 인덱스는 극적인 성능 향상이 없고, 오히려 저장공간을 소모하기에 좋은 방법은 아니라고 판단하여 적용하지 않았다.

## 🧲 참고 자료 및 공유 사항
[🗄️DB 인덱스와 커버링 인덱스](https://velog.io/@789456jang/DB-%EC%9D%B8%EB%8D%B1%EC%8A%A4%EC%99%80-%EC%BB%A4%EB%B2%84%EB%A7%81-%EC%9D%B8%EB%8D%B1%EC%8A%A4)
