### PR TITLE
[refactor] 예외 처리 로직 변경

### DIFF
--- a/server/src/main/java/com/onetool/server/global/new_exception/exception/BaseException.java
+++ b/server/src/main/java/com/onetool/server/global/new_exception/exception/BaseException.java
@@ -1,0 +1,32 @@
+package com.whale.gather_one.global.exception;
+
+import com.whale.gather_one.global.exception.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private String customErrorMessage;
+
+    private BaseException(ErrorCode code) {
+        this.errorCode = code;
+    }
+
+    private BaseException(ErrorCode code, final String message) {
+        this.errorCode = code;
+        this.customErrorMessage = message;
+    }
+
+    public boolean hasCustomMessage(){
+        return customErrorMessage != null;
+    }
+
+    public static BaseException from(ErrorCode errorCode) {
+        return new BaseException(errorCode);
+    }
+
+    public static BaseException from(ErrorCode errorCode, final String customErrorMessage){
+        return new BaseException(errorCode, customErrorMessage);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/new_exception/exception/error/ErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/new_exception/exception/error/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.whale.gather_one.global.exception.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    ;
+
+    private final String code;
+    private final String message;
+    private final ErrorDisplayType displayType;
+}

--- a/server/src/main/java/com/onetool/server/global/new_exception/exception/error/ErrorDisplayType.java
+++ b/server/src/main/java/com/onetool/server/global/new_exception/exception/error/ErrorDisplayType.java
@@ -1,0 +1,7 @@
+package com.whale.gather_one.global.exception.error;
+
+public enum ErrorDisplayType {
+    TOAST,
+    POPUP,
+    MODAL
+}

--- a/server/src/main/java/com/onetool/server/global/new_exception/exception/handler/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/onetool/server/global/new_exception/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.whale.gather_one.global.exception.handler;
+
+import com.whale.gather_one.global.exception.BaseException;
+import com.whale.gather_one.global.exception.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class GlobalExceptionHandler {
+
+    /**
+     * 클라이언트 에러
+     * 직접 생성한 예외에 대한 처리
+     */
+    @ExceptionHandler(BaseException.class)
+    public ErrorResponse onThrowException(BaseException baseException) {
+        return ErrorResponse.generateErrorResponse(baseException);
+    }
+}

--- a/server/src/main/java/com/onetool/server/global/new_exception/exception/response/ErrorResponse.java
+++ b/server/src/main/java/com/onetool/server/global/new_exception/exception/response/ErrorResponse.java
@@ -1,0 +1,33 @@
+package com.whale.gather_one.global.exception.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.whale.gather_one.global.exception.BaseException;
+import com.whale.gather_one.global.exception.error.ErrorDisplayType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"code", "message", "displayType"})
+public class ErrorResponse {
+
+    @JsonProperty("code")
+    private final String code;
+    private final String message;
+    private final ErrorDisplayType displayType;
+
+    public static ErrorResponse generateErrorResponse(BaseException baseException){
+        if(baseException.hasCustomMessage()) {
+            return new ErrorResponse(
+                    baseException.getErrorCode().getCode(),
+                    baseException.getCustomErrorMessage(),
+                    baseException.getErrorCode().getDisplayType());
+        }
+        return new ErrorResponse(
+                baseException.getErrorCode().getCode(),
+                baseException.getErrorCode().getMessage(),
+                baseException.getErrorCode().getDisplayType());
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈
- #177 

## 🔎 작업 내용
새로운 예외 처리 로직을 구현했습니다.
이미 작성한 예외 처리 로직을 수정한 것이 아닌 새로 디렉토리를 만들어서 구현한 것입니다.

### 공통 예외 처리 Response 형식
```
{
	errorCode : "MEMBER-0000",
	message : "회원이 존재하지 않습니다.",
	displayType : "MODAL"
}
```
- displayType => Popup, Toast, Modal : 유저에게 에러를 어떻게 보여줄 것인가?

### 예외 처리 클래스 의존/연관 관계
![예외처리의존관계](https://github.com/user-attachments/assets/f531fc8b-cd14-454d-80ad-1de6b968d812)
- 실선 : 멤버 변수로 가지고 있고, 사용하는 경우
- 점선 : 지역변수로 사용하거나, 파라미터로 사용하는 등 멤버변수로 갖지 않고 사용하는 관계

# 예외 처리 시퀀스

<aside>
💡 개발자가 직접 예외를 선언하는 경우에 따른 시퀀스

</aside>

> 모든 `Exception`을 `BaseException`으로 처리
> 

![예외처리시퀀스](https://github.com/user-attachments/assets/c6655367-ccae-4664-8a68-f41c16705776)


1. `ErrorCode`를 명시하여 `BaseException` 을 발생
2. `BaseException`이 발생하면 `GlobalExceptionHandler`의 `BaseException` 핸들러가 동작
3. `GlobalExceptionHandler`는 `BaseException`에 커스텀 메세지 존재여부 확인
    - 커스텀 메세지 존재 시 정의된 `ErrorCode`의 메세지에 커스텀 메세지를 넣어 인스턴스 생성<1.1.2>
    - 커스텀 메세지 미존재 시 정의된 `ErrorCode`를 통해 인스턴스 생성<1.1.3>
4. HTTP 응답 메세지 Body에 `ErrorResponse` 인스턴스를 전달
+) 추가로 Binding관련 Exception은 따로 Handler를 만들어야 합니다

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

### 1. BaseException을 상속한 여러 커스텀 예외 클래스 삭제

애초에 열거형을 사용해 사용자 정의 예외를 관리한 이유가 각 예외에 대한 클래스를 만들지 않기 위함입니다.

### 2. 모든 에러를 200 OK로 처리
모든 에러는 200 OK로 처리하고 사용자에겐 상태 코드를 보여주지 않습니다. 대신 개발자들만 알도록 약속된 코드를 사용합니다. 예시는 아래와 같습니다.
<img width="836" alt="KakaoTalk_Photo_2025-02-25-19-10-46" src="https://github.com/user-attachments/assets/2cd05402-6b63-44c5-bd23-8c8e3c718a90" />

### 3. 성공 요청은 dto 그대로 반환하고, 예외가 발생한 경우에만 ErrorResponse라는 공통 형식 사용

기존에 사용하던 ApiResponse를 보면
```
{
	isSuccess : Boolean
	code : String
	message : String
	result : {응답으로 필요한 또 다른 json}
}
```
그런데 성공의 경우 result만 사용하지 isSuccess, code, message가 중요하지 않다고 생각합니다. 그래서 예외 발생의 경우에만 ErrorResponse를 사용하고, 요청에 대한 올바른 응답이 간 경우엔 dto나 String을 그대로 반환하려 합니다.

### 4. 응답 Display 형식을 서버가 관리하는 것에 대하여
제 개인적인 생각은 예외와 관련된 부분은 서버, 클라이언트, 유저 모두 상호작용하는 부분이라 생각이 듭니다. 그렇기 때문에 전반적인 예외 처리와 관련된 책임을 서버와 클라이언트가 나눠서 관리하는 것보단 서버가 전부 관리하는 편이 더 낫다고 생각해 이 방법을 선택하게 됐습니다.

[팝업의 종류](https://jeeeeehnmin.tistory.com/entry/%ED%8C%9D%EC%97%85%EC%9D%98-%EC%A2%85%EB%A5%98-%ED%8C%9D%EC%97%85-%EC%95%8C%EB%9F%BF-%EB%A0%88%EC%9D%B4%EC%96%B4-%ED%8C%9D%EC%97%85-%EB%AA%A8%EB%8B%AC-%ED%86%A0%EC%8A%A4%ED%8A%B8-%ED%8C%9D%EC%97%85)

이 부분은 여러분들의 의견이 많이 필요합니다. 많은 코멘트 부탁드리겠습니다.
