### PR TITLE
refactor(member): 회원 예외 구조 변경

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/business/MemberEmailBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/member/business/MemberEmailBusiness.java
@@ -5,8 +5,6 @@ import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.dto.MemberFindPwdRequest;
 import com.onetool.server.api.member.service.MemberService;
 import com.onetool.server.global.annotation.Business;
-import com.onetool.server.global.exception.BusinessLogicException;
-import com.onetool.server.global.exception.codes.ErrorCode;
 import com.onetool.server.global.redis.service.MailRedisService;
 import groovy.util.logging.Slf4j;
 import lombok.RequiredArgsConstructor;

--- a/server/src/main/java/com/onetool/server/api/member/controller/MemberEmailController.java
+++ b/server/src/main/java/com/onetool/server/api/member/controller/MemberEmailController.java
@@ -4,7 +4,6 @@ import com.onetool.server.api.member.business.MemberBusiness;
 import com.onetool.server.api.member.business.MemberEmailBusiness;
 import com.onetool.server.api.member.dto.MemberFindEmailRequest;
 import com.onetool.server.api.member.dto.MemberFindPwdRequest;
-import com.onetool.server.api.member.service.MemberService;
 import com.onetool.server.global.exception.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;

--- a/server/src/main/java/com/onetool/server/api/member/controller/MemberLoginController.java
+++ b/server/src/main/java/com/onetool/server/api/member/controller/MemberLoginController.java
@@ -1,6 +1,5 @@
 package com.onetool.server.api.member.controller;
 
-import com.onetool.server.api.member.business.MemberEmailBusiness;
 import com.onetool.server.api.member.business.MemberLoginBusiness;
 import com.onetool.server.api.member.dto.LoginRequest;
 import com.onetool.server.global.auth.jwt.JwtUtil;

--- a/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
@@ -6,11 +6,10 @@ import com.onetool.server.global.exception.codes.ErrorCode;
 
 import com.onetool.server.api.member.repository.MemberRepository;
 import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.global.new_exception.exception.ApiException;
+import com.onetool.server.global.new_exception.exception.error.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,17 +22,20 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public Member findByNameAndPhoneNumber(String name, String phoneNumber) {
-        return memberRepository.findByNameAndPhoneNum(name, phoneNumber).orElseThrow(() -> new MemberNotFoundException(name));
+        return memberRepository.findByNameAndPhoneNum(name, phoneNumber).orElseThrow(() ->
+                new ApiException(MemberErrorCode.NON_EXIST_USER, "이름과 비밀번호가 일치하는 회원이 존재하지 않습니다."));
     }
 
     @Transactional(readOnly = true)
     public Member findByEmail(String email) {
-        return memberRepository.findByEmail(email).orElseThrow(() -> new MemberNotFoundException(email));
+        return memberRepository.findByEmail(email).orElseThrow(() ->
+                new ApiException(MemberErrorCode.NON_EXIST_USER, "이메일과 일치하는 회원이 존재하지 않습니다."));
     }
 
     @Transactional(readOnly = true)
     public Member findById(Long id) {
-        return memberRepository.findById(id).orElseThrow(() -> new MemberNotFoundException(id.toString()));
+        return memberRepository.findById(id).orElseThrow(() ->
+                new ApiException(MemberErrorCode.NON_EXIST_USER, "ID가 일치하는 회원이 존재하지 않습니다."));
     }
 
     @Transactional
@@ -54,19 +56,19 @@ public class MemberService {
 
     public void validateExistId(Long id) {
         if (!memberRepository.existsById(id)) {
-            throw new BaseException(ErrorCode.NON_EXIST_USER);
+            throw new ApiException(MemberErrorCode.NON_EXIST_USER, "ID가 일치하는 회원이 존재하지 않습니다.");
         }
     }
 
     public void validateDuplicateEmail(String email) {
         if (memberRepository.existsByEmail(email)) {
-            throw new BaseException(ErrorCode.EXIST_EMAIL);
+            throw new ApiException(MemberErrorCode.EXIST_EMAIL, "이미 사용 중인 이메일입니다.");
         }
     }
 
     public Member findMemberWithCartById(Long id) {
         return memberRepository
                 .findByIdWithCart(id)
-                .orElseThrow(() -> new BaseException(NON_EXIST_USER));
+                .orElseThrow(() -> new ApiException(MemberErrorCode.NON_EXIST_USER));
     }
 }

--- a/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
@@ -1,9 +1,5 @@
 package com.onetool.server.api.member.service;
 
-import com.onetool.server.global.exception.*;
-import com.onetool.server.global.exception.base.BaseException;
-import com.onetool.server.global.exception.codes.ErrorCode;
-
 import com.onetool.server.api.member.repository.MemberRepository;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.global.new_exception.exception.ApiException;

--- a/server/src/main/java/com/onetool/server/global/new_exception/exception/error/LoginErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/new_exception/exception/error/LoginErrorCode.java
@@ -8,11 +8,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum LoginErrorCode implements ErrorCodeIfs {
 
-    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "LOGIN-0001", "이메일이 잘못됨"),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-0000", "잘못된 요청입니다."),
-    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "COMMON-0002", "이미 존재하는 회원입니다."),
-    DUPLICATE_MEMBER(HttpStatus.BAD_REQUEST, "COMMON-0003", "기존 회원 정보와 중복됩니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "COMMON-0004", "유효하지 않은 토큰입니다."),
+    INVALID_EMAIL(HttpStatus.NOT_FOUND, "LOGIN-0001", "이메일이 잘못되었습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "LOGIN-0002", "비밀번호가 잘못되었습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "COMMON-0003", "유효하지 않은 토큰입니다."),
+    ILLEGAL_LOGOUT_USER(HttpStatus.BAD_REQUEST, "MEMBER-0004", "이미 로그아웃된 회원입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/server/src/main/java/com/onetool/server/global/new_exception/exception/error/MemberErrorCode.java
+++ b/server/src/main/java/com/onetool/server/global/new_exception/exception/error/MemberErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCodeIfs {
 
     NON_EXIST_USER(HttpStatus.NOT_FOUND, "MEMBER-0001", "존재하지 않는 회원입니다"),
-    ILLEGAL_LOGOUT_USER(HttpStatus.BAD_REQUEST, "MEMBER-0002", "이미 로그아웃된 회원입니다."),
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER-0002", "이미 존재하는 회원입니다."),
+    DUPLICATE_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER-0003", "기존 회원 정보와 중복됩니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ 이슈

- #177 

## 🔎 작업 내용

- 커스텀 예외나 BaseException 대신 `ApiException`을 사용하도록 변경
- MemberErrorCode와 LoginErrorCode 정리

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

### 예외를 발생시킨 값 표시 여부
예를 들어 id가 5인 Member를 찾는 서비스 로직 실행 중 `NON_EXIST_MEMBER`가 발생했다고 해보죠. 이때, **5 라는 값을 커스텀 메시지로 넘기는 것**에 대해 어떻게 생각하시나요?
아래와 같은 코드로 변경하는 것이 의미가 있을지 의견이 궁금합니다!

```java
@Transactional(readOnly = true)
public Member findById(Long id) {
    return memberRepository.findById(id).orElseThrow(() ->
            new ApiException(MemberErrorCode.NON_EXIST_USER, "ID가 일치하는 회원이 존재하지 않습니다. :" + id));
}
```

## 🧲 참고 자료 및 공유 사항

진짜 뜬금없지만, `+`와 `StringBuilder`의 속도 차이에 대한 글도 남겨봐요!
[Compact String 과 String plus연산은 왜느릴까?](https://nelmm.gitbook.io/nelmm/6./compact-string-string-plus)
