### PR TITLE
refactor(filter): 필터 검사시 Member 쿼리자체가 2번 조회되는 문제와 N+1 문제가 발생 해결

### DIFF
--- a/server/src/main/java/com/onetool/server/api/cart/Cart.java
+++ b/server/src/main/java/com/onetool/server/api/cart/Cart.java
@@ -25,7 +25,7 @@ public class Cart extends BaseEntity {
     @JoinColumn(name = "member_cart_id")
     private Member member;
 
-    @OneToMany(mappedBy = "cart", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "cart", fetch = FetchType.LAZY)
     private List<CartBlueprint> cartItems = new ArrayList<>();
 
     private Cart(Member member) {

--- a/server/src/main/java/com/onetool/server/api/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/onetool/server/api/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.onetool.server.api.member.repository;
 
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.enums.SocialType;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +26,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m WHERE m.email = :email")
     boolean existsByEmail(@Param("email") String email);
+
+    @Query("SELECT m FROM Member m LEFT JOIN FETCH m.cart WHERE m.id = :id")
+    Optional<Member> findMemberById(@Param("id") Long id);
+
+
 }

--- a/server/src/main/java/com/onetool/server/global/auth/login/service/CustomUserDetailsService.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/service/CustomUserDetailsService.java
@@ -29,7 +29,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public PrincipalDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        Member member = memberRepository.findById(Long.parseLong(id))
+        Member member = memberRepository.findMemberById(Long.parseLong(id))
                 .orElseThrow(() -> new MemberNotFoundException("해당하는 유저가 없습니다."));
 
         MemberAuthContext context = MemberAuthContext.builder()

--- a/server/src/main/java/com/onetool/server/global/auth/login/service/CustomUserDetailsService.java
+++ b/server/src/main/java/com/onetool/server/global/auth/login/service/CustomUserDetailsService.java
@@ -7,6 +7,7 @@ import com.onetool.server.api.member.repository.MemberRepository;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -21,13 +22,13 @@ import java.util.Collection;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
     @Override
     public PrincipalDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-
         Member member = memberRepository.findById(Long.parseLong(id))
                 .orElseThrow(() -> new MemberNotFoundException("해당하는 유저가 없습니다."));
 
@@ -42,7 +43,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         return new PrincipalDetails(context);
     }
 
-    public void saveUserInSecurityContext(String memberId, String token) {
+    public PrincipalDetails saveUserInSecurityContext(String memberId, String token) {
         if (memberId == null) {
             throw new InvalidTokenException(token);
         }
@@ -55,6 +56,8 @@ public class CustomUserDetailsService implements UserDetailsService {
             SecurityContext context = SecurityContextHolder.createEmptyContext();
             context.setAuthentication(auth);
             SecurityContextHolder.setContext(context);
+            return principalDetails;
         }
+        return null;
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈
[N+1을 통한 성능 리팩터링](#178) 
- close #이슈번호


## 🔎 작업 내용
### 현재 어떤 api를 요청하든지 filter를 거치게 되어 있다.
다만 filter를 거치게 되면 아래와 같이 Member 와 cart가 둘다 각각 조회되는 N+1문제가 발생한다. 
여기서 추가적으로 Member과 한번 더 새롭게 조회되는 문제가 발생했다.
즉 정리하자면 Member cart 조회 그리고 다시 Member cart 조회 .. 이는 매우 비효율적이다.
```
2025-03-05T17:47:50.949+09:00  INFO 15496 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : 토큰: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
2025-03-05T17:47:50.950+09:00  INFO 15496 --- [server] [nio-8080-exec-1] c.o.server.global.auth.jwt.JwtUtil       : parseClaims token: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
Hibernate: 
    select
        m1_0.id,
        m1_0.birth_date,
        m1_0.created_at,
        m1_0.email,
        m1_0.field,
        m1_0.is_deleted,
        m1_0.is_native,
        m1_0.name,
        m1_0.password,
        m1_0.phone_num,
        m1_0.platform_type,
        m1_0.user_role,
        m1_0.service_accept,
        m1_0.social_id,
        m1_0.social_type,
        m1_0.updated_at,
        m1_0.user_registered_at 
    from
        member m1_0 
    where
        m1_0.id=? 
        and (
            m1_0.is_deleted = 0
        )
Hibernate: 
    select
        c1_0.id,
        c1_0.created_at,
        c1_0.member_cart_id,
        c1_0.total_price,
        c1_0.updated_at 
    from
        cart c1_0 
    where
        c1_0.member_cart_id=?
2025-03-05T17:47:51.189+09:00  INFO 15496 --- [server] [nio-8080-exec-1] c.o.server.global.auth.jwt.JwtUtil       : validateToken token: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
2025-03-05T17:47:51.194+09:00  INFO 15496 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : validation 통과
2025-03-05T17:47:51.194+09:00  INFO 15496 --- [server] [nio-8080-exec-1] c.o.server.global.auth.jwt.JwtUtil       : parseClaims token: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
Hibernate: 
    select
        m1_0.id,
        m1_0.birth_date,
        m1_0.created_at,
        m1_0.email,
        m1_0.field,
        m1_0.is_deleted,
        m1_0.is_native,
        m1_0.name,
        m1_0.password,
        m1_0.phone_num,
        m1_0.platform_type,
        m1_0.user_role,
        m1_0.service_accept,
        m1_0.social_id,
        m1_0.social_type,
        m1_0.updated_at,
        m1_0.user_registered_at 
    from
        member m1_0 
    where
        m1_0.id=? 
        and (
            m1_0.is_deleted = 0
        )
Hibernate: 
    select
        c1_0.id,
        c1_0.created_at,
        c1_0.member_cart_id,
        c1_0.total_price,
        c1_0.updated_at 
    from
        cart c1_0 
    where
        c1_0.member_cart_id=?
2025-03-05T17:47:51.203+09:00  INFO 15496 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : 필터 설정됨: 
```
------------------------
### 그래서 먼저 저는 Member와 cart 가 각각 2번씩 조회되는 것을 한번으로 줄이게 코드를 리팩터링 했습니다.
2번씩 조회 됬던 이유는 아래에 있는 해당 함수가 하나의 필터 안에 2번 조회가 되게 코드가 구현되어 있었습니다.
![image](https://github.com/user-attachments/assets/f048fae8-a9a0-47ad-9daf-9e07f73ab6a7)
그래서 commit한 내용대로 필터 안에 1번 조회가 되게 코드를 리팩터링 시켰습니다. 
아래는 결과쿼리 입니다. 
```
2025-03-05T17:53:21.526+09:00  INFO 24840 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : 토큰: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
2025-03-05T17:53:21.526+09:00  INFO 24840 --- [server] [nio-8080-exec-1] c.o.server.global.auth.jwt.JwtUtil       : parseClaims token: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
Hibernate: 
    select
        m1_0.id,
        m1_0.birth_date,
        m1_0.created_at,
        m1_0.email,
        m1_0.field,
        m1_0.is_deleted,
        m1_0.is_native,
        m1_0.name,
        m1_0.password,
        m1_0.phone_num,
        m1_0.platform_type,
        m1_0.user_role,
        m1_0.service_accept,
        m1_0.social_id,
        m1_0.social_type,
        m1_0.updated_at,
        m1_0.user_registered_at 
    from
        member m1_0 
    where
        m1_0.id=? 
        and (
            m1_0.is_deleted = 0
        )
Hibernate: 
    select
        c1_0.id,
        c1_0.created_at,
        c1_0.member_cart_id,
        c1_0.total_price,
        c1_0.updated_at 
    from
        cart c1_0 
    where
        c1_0.member_cart_id=?
2025-03-05T17:53:21.736+09:00  INFO 24840 --- [server] [nio-8080-exec-1] c.o.server.global.auth.jwt.JwtUtil       : validateToken token: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
2025-03-05T17:53:21.743+09:00  INFO 24840 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : validation 통과
2025-03-05T17:53:21.744+09:00  INFO 24840 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : 필터 설정됨: 
2025-03-05T17:53:22.140+09:00  WARN 24840 --- [server] [nio-8080-exec-1] o.a.c.util.SessionIdGeneratorBase        : Creation of SecureRandom instance for session ID generation using 
```
------------------
### 그러나 아직 member 만 조회했는데 cart까지 조회되는 N+1문제는 해결되지 않아서 이 부분도 코드 리팩터링 시켰습니다.
@OnetoOne 이 친구는 양방향 연관관계를 적용했을 시 lazy가 안먹는 경우가 존재합니다. 
FetchType.Lazy를 설정을 모두 완벽하게 했음에도 불구하고 해당 N+1문제가 발생했따.
이유는 아래와 같다.

*** 프록시는 반드시 해당 객체가 null이지 않는 실제 값이 있어야 된다.
그래야만 프록시 객체를 만들어서 Lazy를 진행 시킬 수 있다.

Member 와 cart중 연관관계 주인은 cart이다 
쉽게 말하자면 외래키를 가진 사람은 cart이다.
Member는 외래키를 갖고 있지 않다. 그래서 Member를 조회할 경우 cart라는 객체가 null인지 아니면 실제로 값이 있는지를 알고 싶어한다. Hibernate는 해당 객체가 null일경우 그냥 null을 주입하고 실제로 있다면 프록시 객체를 생성하여 LAZY를 구현한다.

### 그런데 Member는 외래키를 갖고 있지 않다. 그래서 Hibernate는 Cart라는 객체가 null인지 실제 값이 있는지 판단할 근거가 없다.
결국 lazy로 설정했음에도 불구하고 Hibernate는 Cart의 쿼리를 실제로 날려서 해당 객체가 null인지 아니면 실제로 있는지 판단한 후 둘중 하나의 결과를 얻게 된다. 결국 어떠한 경우든지 간에 쿼리를 날려 N+1문제를 유발한다.

그렇다면 연관관계 주인인 (외래키를 가진) Cart는 어떨까? 
외래키를 가진 객체가 존재하기 때문에 member 해당 객체를 검사하여 null인지 아닌지 판단한후 프록시 객체를 만든다.
N+1문제가 발생되지 않는다.

그렇다면 @OneToMany 는 어떻게 될까??
List<qnaReply> qnaReplyList 형태로 선언되어 있을 것이다.
컬랙션은 일단 프록시 객체를 만들수 있따. 컬랙션이 아무런 값도 없어도 만들 수 있다.
그 이유는 qnaReplyList.size() == 0 인 경우로 판단하여 null은 상관하지 않기 때문이다.
```
2025-03-05T18:00:56.181+09:00  INFO 25544 --- [server] [(3)-172.21.48.1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 24 ms
2025-03-05T18:01:00.783+09:00  INFO 25544 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : 토큰: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
2025-03-05T18:01:00.783+09:00  INFO 25544 --- [server] [nio-8080-exec-1] c.o.server.global.auth.jwt.JwtUtil       : parseClaims token: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
Hibernate: 
    select
        m1_0.id,
        m1_0.birth_date,
        c1_0.id,
        c1_0.created_at,
        c1_0.total_price,
        c1_0.updated_at,
        m1_0.created_at,
        m1_0.email,
        m1_0.field,
        m1_0.is_deleted,
        m1_0.is_native,
        m1_0.name,
        m1_0.password,
        m1_0.phone_num,
        m1_0.platform_type,
        m1_0.user_role,
        m1_0.service_accept,
        m1_0.social_id,
        m1_0.social_type,
        m1_0.updated_at,
        m1_0.user_registered_at 
    from
        member m1_0 
    left join
        cart c1_0 
            on m1_0.id=c1_0.member_cart_id 
    where
        (
            m1_0.is_deleted = 0
        ) 
        and m1_0.id=?
2025-03-05T18:01:01.028+09:00  INFO 25544 --- [server] [nio-8080-exec-1] c.o.server.global.auth.jwt.JwtUtil       : validateToken token: eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJra2QwNjE0NEBuYXZlci5jb20iLCJtZW1iZXJJZCI6MywiaWF0IjoxNzQxMTU0NjcwLCJleHAiOjI5NTA3NTQ3MDN9.26FIzgFueAFHClrmXuwb3kL4_LL2tBNhG_t4hiaQ6p8
2025-03-05T18:01:01.041+09:00  INFO 25544 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : validation 통과
2025-03-05T18:01:01.042+09:00  INFO 25544 --- [server] [nio-8080-exec-1] c.o.s.global.auth.filter.JwtAuthFilter   : 필터 설정됨: 
```
-------------------
### 결과적으로 N+1문제 및 Member 2번 조회되는 문제를 해결했습니다.

자세한 내용은 아래 블로그를 참고하면 됩니다.

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항


### 1.
@OnetoOne 고질적인 해당 N+1문제를 완전히 해결하는 방법은 없다고 합니다.
현재 저는 fetch join 을 이용하여 아싸리 Member를 조회시 cart를 같이 join해서 결과를 가져오는 형태로 해당 문제를 해결했습니다.

### 2.
다른 방식으로는 MemberDto를 직접 만들어 데이터베이스에서 데이터를 가져올때 바인딩하는 방식도 있다고 합니다.
Optional<MemberDto> findById(Long id); 

### 어떤 방식이 좋을지 논의하고 싶어요~  다른 방식도 있을지 궁금합니다!!

### 시간 변화에서의 극적인 변화는 없다. 아래 사진에 첨부했습니다.
Data가 많다고 한들 idx==3 형태로 특정 인덱스로 조회를 하는 const 조회 방식이다.
또한 OneToOne 관계 즉 1:1관계라 데이터가 많아진다고 한들 다른 쿼리가 부차적으로 발생되지 않은 이유도 큰 몫을 하였다.


새로운 N+1 발생하는 문제를 찾아서 기분이 좋네요 : )



## 🧲 참고 자료 및 공유 사항
[@OneToOne N+1 문제 해결 주신 블로그](https://jeong-pro.tistory.com/249)

### Mysql로 따로 쿼리를 생성하여 진행 

### [N+1 과 2번 Memebr 조회 시간] = 74 + 133 + 113 + 140 = 460ms 
![image](https://github.com/user-attachments/assets/b1008620-fae3-485e-af99-2c30efb37f9c)

### [N+1 문제만 ] = 58 + 71 = 129ms
![image](https://github.com/user-attachments/assets/95bf88f8-7aef-41be-9b1f-d87d9240c97e)

### [해결 후] = 55ms 
![image](https://github.com/user-attachments/assets/b577b8cb-3a5d-4946-be97-f67a6aa47161)


