### PR TITLE
test(member): Mockito를 이용한 controller - business - service 테스트 작성

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 	// https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/onetool/server/api/member/dto/BlueprintDownloadResponse.java
+++ b/server/src/main/java/com/onetool/server/api/member/dto/BlueprintDownloadResponse.java
@@ -2,7 +2,9 @@ package com.onetool.server.api.member.dto;
 
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.order.OrderBlueprint;
+import lombok.Builder;
 
+@Builder
 public record BlueprintDownloadResponse(
         Long blueprintId,
         String blueprintImage,

--- a/server/src/main/java/com/onetool/server/api/qna/repository/QnaBoardRepository.java
+++ b/server/src/main/java/com/onetool/server/api/qna/repository/QnaBoardRepository.java
@@ -4,10 +4,12 @@ import com.onetool.server.api.qna.QnaBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface QnaBoardRepository extends JpaRepository<QnaBoard, Long> {
 
     @Query("SELECT q FROM QnaBoard q ORDER BY q.createdAt DESC")

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -1,11 +1,11 @@
 spring.application.name=server
 
-spring.jpa.properties.hibernate.show_sql=false
+spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 

--- a/server/src/test/java/com/onetool/server/api/helper/MockBeanInjection.java
+++ b/server/src/test/java/com/onetool/server/api/helper/MockBeanInjection.java
@@ -1,0 +1,20 @@
+package com.onetool.server.api.helper;
+
+import com.onetool.server.api.member.business.MemberBusiness;
+import com.onetool.server.api.member.service.MemberService;
+import com.onetool.server.api.qna.business.QnaBoardBusiness;
+import com.onetool.server.global.auth.jwt.JwtUtil;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@MockBean(JpaMetamodelMappingContext.class)
+public class MockBeanInjection {
+    @MockBean
+    private JwtUtil jwtUtil;
+    @MockBean
+    protected MemberService memberService;
+    @MockBean
+    protected MemberBusiness memberBusiness;
+    @MockBean
+    protected QnaBoardBusiness qnaBoardBusiness;
+}

--- a/server/src/test/java/com/onetool/server/api/member/business/MemberBusinessTest.java
+++ b/server/src/test/java/com/onetool/server/api/member/business/MemberBusinessTest.java
@@ -1,29 +1,32 @@
 package com.onetool.server.api.member.business;
 
+import com.onetool.server.api.member.fixture.MemberFixture;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.dto.*;
-import com.onetool.server.api.member.enums.UserRole;
-import com.onetool.server.api.member.fake.FakeMemberRepository;
 import com.onetool.server.api.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class MemberBusinessTest {
 
+    @InjectMocks
     private MemberBusiness memberBusiness;
+
+    @Mock
     private MemberService memberService;
-    private FakeMemberRepository memberRepository;
+
+    @Mock
     private PasswordEncoder encoder;
 
     private Member member;
@@ -31,131 +34,80 @@ class MemberBusinessTest {
 
     @BeforeEach
     void setup() {
-        memberRepository = new FakeMemberRepository();
-        memberService = new MemberService(memberRepository);
-        encoder = new BCryptPasswordEncoder();
-        memberBusiness = new MemberBusiness(encoder, memberService);
+        MockitoAnnotations.openMocks(this);
 
-        admin = memberRepository.save(
-                Member.builder()
-                        .name("관리자 윤성원")
-                        .password(encoder.encode("1234"))
-                        .email("admin@example.com")
-                        .role(UserRole.ROLE_ADMIN)
-                        .phoneNum("01012345678")
-                        .field("백엔드")
-                        .isNative(true)
-                        .build()
-        );
+        member = MemberFixture.createMember();
+        member.setPassword(encoder.encode("1234"));
 
-        member = memberRepository.save(
-                Member.builder()
-                        .name("홍길동")
-                        .password(encoder.encode("1234"))
-                        .email("user@example.com")
-                        .role(UserRole.ROLE_ADMIN)
-                        .phoneNum("01000000000")
-                        .field("백엔드")
-                        .isNative(true)
-                        .build()
-        );
+        admin = MemberFixture.createAdmin();
+        admin.setPassword(encoder.encode("1234"));
     }
 
     @Test
-    void 이메일로_회원을_조회한다() {
+    void 회원의_이메일을_조회한다() {
         // given
         MemberFindEmailRequest request = new MemberFindEmailRequest("홍길동", "01000000000");
+        when(memberService.findOne(request.name(), request.phone_num())).thenReturn(member);
 
         // when
         String email = memberBusiness.findEmail(request);
 
         // then
         assertThat(email).isEqualTo(member.getEmail());
+        verify(memberService, times(1)).findOne(request.name(), request.phone_num());
     }
 
     @Test
     void 회원의_정보를_조회한다() {
         // given
-        final Long userId = member.getId();
+        when(memberService.findOne(member.getId())).thenReturn(member);
 
         // when
-        MemberInfoResponse response = memberBusiness.getMemberInfo(userId);
+        MemberInfoResponse response = memberBusiness.getMemberInfo(member.getId());
 
         // then
         assertThat(response.email()).isEqualTo(member.getEmail());
-    }
-
-    /*
-    구매한 도면을 조회하기 위해선 주문 데이터를 생성해야 한다.
-    MemberTest에서 주문 데이터를 생성하는 과정이 포함되어도 되는 것일까?
-     */
-    @Test
-    void 회원의_구매한_도면목록을_조회한다() {
-        // given
-        final Long userId = member.getId();
-
-        // when
-        List<BlueprintDownloadResponse> response = memberBusiness.getPurchasedBlueprints(userId);
-
-        // then
-
+        verify(memberService, times(1)).findOne(member.getId());
     }
 
     @Test
     void 회원을_생성한다() {
         // given
-        final String email = "iamuser12@gmail.com";
-        final String name = "임홍빈";
-
-        MemberCreateRequest request = new MemberCreateRequest(
-                email,
-                "iamuser123",
-                name,
-                "2024-01-01",
-                "BACKEND",
-                "01034235512",
-                true
-        );
+        MemberCreateRequest request = MemberFixture.createMemberCreateRequest();
+        when(memberService.save(any(Member.class))).thenReturn(member);
 
         // when
         MemberCreateResponse response = memberBusiness.createMember(request);
 
         // then
-        assertThat(response.email()).isEqualTo(email);
-        assertThat(response.name()).isEqualTo(name);
+        assertThat(response.email()).isEqualTo(member.getEmail());
+        assertThat(response.name()).isEqualTo(member.getName());
+        verify(memberService, times(1)).save(any(Member.class));
     }
 
     @Test
     void 회원의_이름을_업데이트한다() {
         // given
-        final Long userId = member.getId();
-        final String name = "동길홍";
-        MemberUpdateRequest request = MemberUpdateRequest.builder()
-                .name(name)
-                .build();
+        MemberUpdateRequest request = MemberFixture.createMemberUpdateRequest();
+        when(memberService.findOne(member.getId())).thenReturn(member);
 
         // when
-        memberBusiness.updateMember(userId, request);
+        memberBusiness.updateMember(member.getId(), request);
 
         // then
-        String updatedName = memberRepository.findById(userId)
-                .orElseThrow()
-                .getName();
-        assertThat(updatedName).isEqualTo(name);
+        verify(memberService).save(member);
     }
 
     @Test
     void 회원을_삭제한다() {
         // given
-        final Long userId = member.getId();
+        when(memberService.findOne(member.getId())).thenReturn(member);
+        doNothing().when(memberService).delete(member);
 
         // then
-        memberBusiness.deleteMember(userId);
+        memberBusiness.deleteMember(member.getId());
 
         // when
-        assertThatThrownBy(() -> memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다")))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("유저가 존재하지 않습니다");
+        verify(memberService).delete(any(Member.class));
     }
 }

--- a/server/src/test/java/com/onetool/server/api/member/business/MemberBusinessTest.java
+++ b/server/src/test/java/com/onetool/server/api/member/business/MemberBusinessTest.java
@@ -8,9 +8,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
 class MemberBusinessTest {
 
     @InjectMocks
@@ -30,17 +32,11 @@ class MemberBusinessTest {
     private PasswordEncoder encoder;
 
     private Member member;
-    private Member admin;
 
     @BeforeEach
     void setup() {
-        MockitoAnnotations.openMocks(this);
-
         member = MemberFixture.createMember();
         member.setPassword(encoder.encode("1234"));
-
-        admin = MemberFixture.createAdmin();
-        admin.setPassword(encoder.encode("1234"));
     }
 
     @Test

--- a/server/src/test/java/com/onetool/server/api/member/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/onetool/server/api/member/controller/MemberControllerTest.java
@@ -1,0 +1,182 @@
+package com.onetool.server.api.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onetool.server.api.helper.MockBeanInjection;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.dto.MemberCreateRequest;
+import com.onetool.server.api.member.dto.MemberCreateResponse;
+import com.onetool.server.api.member.dto.MemberInfoResponse;
+import com.onetool.server.api.member.dto.MemberUpdateRequest;
+import com.onetool.server.api.member.fixture.MemberFixture;
+import com.onetool.server.api.member.fixture.WithMockPrincipalDetails;
+import com.onetool.server.global.auth.MemberAuthContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureMockMvc
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest extends MockBeanInjection {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Member member;
+
+    @BeforeEach
+    void setup() {
+        member = MemberFixture.createMember();
+    }
+
+    @Test
+    @WithMockUser(username = "test@gmail.com", password = "0000")
+    void 회원을_생성한다() throws Exception {
+        // given
+        MemberCreateRequest request = MemberFixture.createMemberCreateRequest();
+        MemberCreateResponse response = MemberFixture.createMemberCreateResponse();
+        when(memberBusiness.createMember(request)).thenReturn(response);
+
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(post("/users/signup")
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("result.email").value("user@example.com"));
+    }
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 회원_정보를_업데이트한다() throws Exception {
+        // Given
+        MemberUpdateRequest request = MemberFixture.createMemberUpdateRequest();
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        doNothing().when(memberBusiness).updateMember(Mockito.anyLong(), Mockito.any(MemberUpdateRequest.class));
+
+        // When
+        ResultActions result = mockMvc.perform(
+                patch("/users")
+                        .content(jsonRequest)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("회원 정보가 수정되었습니다."));
+    }
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 회원을_삭제한다() throws Exception {
+        // Given
+        doNothing().when(memberBusiness).deleteMember(Mockito.anyLong());
+
+        // When
+        ResultActions result = mockMvc.perform(
+                delete("/users")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("회원 탈퇴가 완료되었습니다."));
+    }
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 회원_정보를_조회한다() throws Exception{
+        // Given
+        when(memberBusiness.getMemberInfo(Mockito.anyLong())).thenReturn(MemberInfoResponse.from(member));
+
+        // When
+        ResultActions result = mockMvc.perform(
+                get("/users")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(2))
+                .andExpect(jsonPath("$.result.email").value(member.getEmail()))
+                .andExpect(jsonPath("$.result.name").value(member.getName()));
+    }
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 회원의_문의내역을_조회한다() throws Exception {
+        // Given
+        when(qnaBoardBusiness.getMyQna(any(MemberAuthContext.class)))
+                .thenReturn(MemberFixture.createQnaBoardBriefResponses());
+
+        // When
+        ResultActions result = mockMvc.perform(
+                get("/users/myQna")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.length()").value(2))
+                .andExpect(jsonPath("$.result[0].title").value("test1"))
+                .andExpect(jsonPath("$.result[0].writer").value("writer1"))
+                .andExpect(jsonPath("$.result[1].title").value("test2"))
+                .andExpect(jsonPath("$.result[1].writer").value("writer2"));
+    }
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 회원의_구매내역을_조회한다() throws Exception {
+        // Given
+        when(memberBusiness.getPurchasedBlueprints(any(Long.class)))
+                .thenReturn(MemberFixture.createBlueprintDownloadResponses());
+
+        // When
+        ResultActions result = mockMvc.perform(
+                get("/users/myPurchase")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.length()").value(2))
+                .andExpect(jsonPath("$.result[0].blueprintName").value("도면1"))
+                .andExpect(jsonPath("$.result[0].blueprintId").value("1"))
+                .andExpect(jsonPath("$.result[1].blueprintName").value("도면2"))
+                .andExpect(jsonPath("$.result[1].blueprintId").value("2"));
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/member/fake/FakeMemberRepository.java
+++ b/server/src/test/java/com/onetool/server/api/member/fake/FakeMemberRepository.java
@@ -83,6 +83,11 @@ public class FakeMemberRepository implements MemberRepository {
                 .anyMatch(m -> m.getEmail().equals(email));
     }
 
+    @Override
+    public Optional<Member> findMemberById(Long id) {
+        return Optional.empty();
+    }
+
     public void clear() {
         store.clear();
     }

--- a/server/src/test/java/com/onetool/server/api/member/fixture/MemberFixture.java
+++ b/server/src/test/java/com/onetool/server/api/member/fixture/MemberFixture.java
@@ -1,0 +1,52 @@
+package com.onetool.server.api.member.fixture;
+
+import com.onetool.server.api.cart.Cart;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.dto.MemberCreateRequest;
+import com.onetool.server.api.member.dto.MemberUpdateRequest;
+import com.onetool.server.api.member.enums.UserRole;
+
+public class MemberFixture {
+
+    public static Member createAdmin() {
+        return Member.builder()
+                .id(1L)
+                .name("관리자 윤성원")
+                .email("admin@example.com")
+                .role(UserRole.ROLE_ADMIN)
+                .phoneNum("01012345678")
+                .field("BACKEND")
+                .isNative(true)
+                .build();
+    }
+
+    public static Member createMember() {
+        return Member.builder()
+                .id(2L)
+                .name("홍길동")
+                .email("user@example.com")
+                .role(UserRole.ROLE_ADMIN)
+                .phoneNum("01000000000")
+                .field("BACKEND")
+                .isNative(true)
+                .build();
+    }
+
+    public static MemberCreateRequest createMemberCreateRequest() {
+        return new MemberCreateRequest(
+                "user@example.com",
+                "1234",
+                "홍길동",
+                "2024-01-01",
+                "BACKEND",
+                "01000000000",
+                true
+        );
+    }
+
+    public static MemberUpdateRequest createMemberUpdateRequest() {
+        return MemberUpdateRequest.builder()
+                .name("길동홍")
+                .build();
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/member/fixture/MemberFixture.java
+++ b/server/src/test/java/com/onetool/server/api/member/fixture/MemberFixture.java
@@ -1,10 +1,11 @@
 package com.onetool.server.api.member.fixture;
 
-import com.onetool.server.api.cart.Cart;
 import com.onetool.server.api.member.domain.Member;
-import com.onetool.server.api.member.dto.MemberCreateRequest;
-import com.onetool.server.api.member.dto.MemberUpdateRequest;
+import com.onetool.server.api.member.dto.*;
 import com.onetool.server.api.member.enums.UserRole;
+import com.onetool.server.api.qna.dto.response.QnaBoardBriefResponse;
+
+import java.util.*;
 
 public class MemberFixture {
 
@@ -44,9 +45,31 @@ public class MemberFixture {
         );
     }
 
+    public static MemberCreateResponse createMemberCreateResponse() {
+        return MemberCreateResponse.builder()
+                .id(2L)
+                .name("홍길동")
+                .email("user@example.com")
+                .build();
+    }
+
     public static MemberUpdateRequest createMemberUpdateRequest() {
         return MemberUpdateRequest.builder()
                 .name("길동홍")
                 .build();
+    }
+
+    public static List<QnaBoardBriefResponse> createQnaBoardBriefResponses() {
+        List<QnaBoardBriefResponse> responses = new ArrayList<>();
+        responses.add(QnaBoardBriefResponse.builder().title("test1").writer("writer1").build());
+        responses.add(QnaBoardBriefResponse.builder().title("test2").writer("writer2").build());
+        return responses;
+    }
+
+    public static List<BlueprintDownloadResponse> createBlueprintDownloadResponses() {
+        List<BlueprintDownloadResponse> responses = new ArrayList<>();
+        responses.add(BlueprintDownloadResponse.builder().blueprintId(1L).blueprintName("도면1").build());
+        responses.add(BlueprintDownloadResponse.builder().blueprintId(2L).blueprintName("도면2").build());
+        return responses;
     }
 }

--- a/server/src/test/java/com/onetool/server/api/member/fixture/WithMockPrincipalDetails.java
+++ b/server/src/test/java/com/onetool/server/api/member/fixture/WithMockPrincipalDetails.java
@@ -1,0 +1,12 @@
+package com.onetool.server.api.member.fixture;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockPrincipalDetailsSecurityContextFactory.class)
+public @interface WithMockPrincipalDetails {
+    long id() default 2L;
+}

--- a/server/src/test/java/com/onetool/server/api/member/fixture/WithMockPrincipalDetailsSecurityContextFactory.java
+++ b/server/src/test/java/com/onetool/server/api/member/fixture/WithMockPrincipalDetailsSecurityContextFactory.java
@@ -1,0 +1,33 @@
+package com.onetool.server.api.member.fixture;
+
+import com.onetool.server.global.auth.MemberAuthContext;
+import com.onetool.server.global.auth.login.PrincipalDetails;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockPrincipalDetailsSecurityContextFactory
+implements WithSecurityContextFactory<WithMockPrincipalDetails> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockPrincipalDetails annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        // PrincipalDetails 및 MemberAuthContext Mock 객체 생성
+        PrincipalDetails principalDetails = Mockito.mock(PrincipalDetails.class);
+        MemberAuthContext authContext = Mockito.mock(MemberAuthContext.class);
+
+        Mockito.when(principalDetails.getContext()).thenReturn(authContext);
+        Mockito.when(authContext.getId()).thenReturn(annotation.id());
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                principalDetails, null, principalDetails.getAuthorities()
+        );
+
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/member/service/MemberServiceTest.java
+++ b/server/src/test/java/com/onetool/server/api/member/service/MemberServiceTest.java
@@ -1,0 +1,189 @@
+package com.onetool.server.api.member.service;
+
+import com.onetool.server.api.cart.Cart;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.fake.FakeMemberRepository;
+import com.onetool.server.api.member.fixture.MemberFixture;
+import com.onetool.server.global.new_exception.exception.ApiException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MemberServiceTest {
+
+    private MemberService memberService;
+    private FakeMemberRepository memberRepository;
+    private PasswordEncoder encoder;
+
+    private Member member;
+    private Cart cart;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = new FakeMemberRepository();
+        memberService = new MemberService(memberRepository);
+        encoder = new BCryptPasswordEncoder();
+
+        member = MemberFixture.createMember();
+        cart = Cart.createCart(member);
+    }
+
+    @Test
+    void 이름과_전화번호로_회원을_조회한다() {
+        // given
+        memberRepository.save(member);
+
+        // when
+        Member foundMember = memberService.findOne(member.getName(), member.getPhoneNum());
+
+        // then
+        assertThat(foundMember.getEmail()).isEqualTo(member.getEmail());
+    }
+
+    @Test
+    void 잘못된_이름과_전화번호로_회원을_조회시_예외가_발생한다() {
+        // given
+        memberRepository.save(member);
+
+        final String wrongName = "아무개";
+        final String wrongPhoneNum = "01033456789";
+
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.findOne(wrongName, wrongPhoneNum))
+                .isInstanceOf(ApiException.class)
+                .extracting("customErrorMessage")
+                .isEqualTo("이름과 비밀번호가 일치하는 회원이 존재하지 않습니다.");
+    }
+
+    @Test
+    void 이메일로_회원을_조회한다() {
+        // given
+        memberRepository.save(member);
+
+        // when
+        Member foundMember = memberService.findOne(member.getEmail());
+
+        // then
+        assertThat(foundMember.getEmail()).isEqualTo(member.getEmail());
+    }
+
+    @Test
+    void 잘못된_이메일로_회원을_조회시_예외가_발생한다() {
+        // given
+        memberRepository.save(member);
+        final String wrongEmail = "aldlld231@gmail.com";
+
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.findOne(wrongEmail))
+                .isInstanceOf(ApiException.class)
+                .extracting("customErrorMessage")
+                .isEqualTo("이메일과 일치하는 회원이 존재하지 않습니다.");
+    }
+
+    @Test
+    void ID로_회원을_조회한다() {
+        // given
+        memberRepository.save(member);
+
+        // when
+        Member foundMember = memberService.findOne(member.getId());
+
+        // then
+        assertThat(foundMember.getId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    void 잘못된_ID로_회원을_조회시_예외가_발생한다() {
+        // given
+        memberRepository.save(member);
+        final Long wrongId = 10L;
+
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.findOne(wrongId))
+                .isInstanceOf(ApiException.class)
+                .extracting("customErrorMessage")
+                .isEqualTo("ID가 일치하는 회원이 존재하지 않습니다.");
+    }
+
+    @Test
+    void 회원을_삭제한다() {
+        // given
+        memberRepository.save(member);
+
+        // when
+        memberService.delete(member);
+
+        // then
+        assertThat(memberRepository.findById(member.getId()).isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    void 회원을_저장한다() {
+        // given
+        // when
+        memberService.save(member);
+
+        // then
+        assertThat(memberRepository.findById(member.getId()).isPresent()).isEqualTo(true);
+    }
+
+    @Test
+    void 회원의_비밀번호를_변경한다() {
+        // given
+        final String encodedNewPassword = encoder.encode("hello123");
+
+        // when
+        memberService.updatePassword(member, encodedNewPassword);
+
+        // then
+        String foundPassword = memberService.findOne(member.getId()).getPassword();
+        assertThat(foundPassword).isEqualTo(encodedNewPassword);
+    }
+
+    @Test
+    void ID를_가진_회원이_없는_경우_예외가_발생한다() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.validateExistId(member.getId()))
+                .isInstanceOf(ApiException.class)
+                .extracting("customErrorMessage")
+                .isEqualTo("ID가 일치하는 회원이 존재하지 않습니다.");
+    }
+
+    @Test
+    void 이메일이_중복되는경우_예외가_발생한다() {
+        // given
+        memberRepository.save(member);
+
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.validateDuplicateEmail(member.getEmail()))
+                .isInstanceOf(ApiException.class)
+                .extracting("customErrorMessage")
+                .isEqualTo("이미 사용 중인 이메일입니다.");
+    }
+
+    @Test
+    void 회원ID로_장바구니와_회원_정보를_조회한다() {
+        // given
+        memberRepository.save(member);
+
+        // when
+        Member foundMember = memberService.findOneWithCart(member.getId());
+
+        // then
+        assertThat(foundMember.getCart()).isNotNull();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈

- #210


## 🔎 작업 내용

- MemberFixture 생성
- 테스트 더블을 이용한 Service 테스트 코드 작성
- Mockito를 이용한 Business 테스트 코드 작성
- Mockito를 이용한 Controller 테스트 코드 작성
- Spring Security를 위한 CustomMockUser 생성

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
### Fixture에 대해
현재 MemberFixture에는 Stubbing을 위해 DTO를 생성하는 메서드를 만들었습니다.

**MemberFixture**
```java
public static MemberCreateResponse createMemberCreateResponse() {
    return MemberCreateResponse.builder()
            .id(2L)
            .name("홍길동")
            .email("user@example.com")
            .build();
}
```

```java
    @Test
    @WithMockUser(username = "test@gmail.com", password = "0000")
    void 회원을_생성한다() throws Exception {
        // given
        MemberCreateRequest request = MemberFixture.createMemberCreateRequest();
        MemberCreateResponse response = MemberFixture.createMemberCreateResponse();
        when(memberBusiness.createMember(request)).thenReturn(response); // ✅ 여기서 사용

        // when
        ResultActions resultActions =
                mockMvc.perform(post("/users/signup")
                        .content(objectMapper.writeValueAsString(request))
                        .with(csrf())
                        .contentType(MediaType.APPLICATION_JSON));

        //then
        resultActions
                .andExpect(status().isOk())
                .andExpect(jsonPath("result.email").value("user@example.com"));
    }
```

이렇게 DTO를 Fixture를 통해 생성하는 것이 문제가 될지 생각이 궁금합니다.

### Spring Security를 위한 테스트 코드
많은 Controller에서 `@AuthenticationPrincipal`을 통해 로그인한 유저 정보를 받아와 사용하고 있습니다. 테스트 코드 그 중, 컨트롤러 테스트 코드에서 해당 어노테이션 파라미터를 어떻게 주입할 수 있을지 생각했습니다.
<br/>
첫번째는 `@WithMockUser`를 사용하는 방식입니다. 그러나 해당 어노테이션의 경우 저희가 사용하는 JWT 토큰을 SecurityContext에 직접 주입해주지 않기 때문에 302 에러가 발생합니다.

두번째 방법은 `JwtUtil`을 이용하여 테스트 코드 내에서 SecurityContext에 주입하는 방식입니다. 해당 방식의 경우, 코드가 길어져 테스트 코드의 가독성을 떨어뜨립니다. 또한 JwtUtil을 MockBean으로 등록하기 위해 accessToken을 생성하는 메서드를 추가로 작성하여 매우 번거롭습니다.

세번째 방법은 `@WithSecurityContext`을 사용하는 방식입니다. 해당 어노테이션은 SecurityContext에 토큰을 저장하는 코드를 모듈화하도록 합니다. 또한 해당 어노테이션을 커스텀 어노테이션을 달아서 모듈화할 수 있다는 장점이 있습니다.

**[ WithMockPrincipalDetails ]**
```java
@Retention(RetentionPolicy.RUNTIME)
@WithSecurityContext(factory = WithMockPrincipalDetailsSecurityContextFactory.class)
public @interface WithMockPrincipalDetails {
    long id() default 2L;
}
```

**[ WithMockPrincipalDetailsSecurityContextFactory ]**

```java
public class WithMockPrincipalDetailsSecurityContextFactory
implements WithSecurityContextFactory<WithMockPrincipalDetails> {

    @Override
    public SecurityContext createSecurityContext(WithMockPrincipalDetails annotation) {
        SecurityContext context = SecurityContextHolder.createEmptyContext();

        // PrincipalDetails 및 MemberAuthContext Mock 객체 생성
        PrincipalDetails principalDetails = Mockito.mock(PrincipalDetails.class);
        MemberAuthContext authContext = Mockito.mock(MemberAuthContext.class);

        Mockito.when(principalDetails.getContext()).thenReturn(authContext);
        Mockito.when(authContext.getId()).thenReturn(annotation.id());

        Authentication authentication = new UsernamePasswordAuthenticationToken(
                principalDetails, null, principalDetails.getAuthorities()
        );

        context.setAuthentication(authentication);
        return context;
    }
}
```
또한 이 방식을 통해 독자적으로 사용중인 `PrincipalDetails`를 등록할 수 있어 코드가 정상적으로 작동한다.

### MockBeanInjection에 대해
MemberController를 테스트하는 코드를 작성한다고 가정해봅니다. 그 경우, 매우 많은 `MockBean`을 주입해야 하기 때문에 필드가 길어져 가독성을 해치는 사태가 발생합니다.

**[ MemberControllerTest ]**
```java
@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@SuppressWarnings("NonAsciiCharacters")
@AutoConfigureMockMvc
@WebMvcTest(controllers = MemberController.class)
class MemberControllerTest extends MockBeanInjection {

    @Autowired
    private MockMvc mockMvc;

    @Autowired
    private ObjectMapper objectMapper;

	@MockBean
    private JwtUtil jwtUtil;
    @MockBean
    protected MemberService memberService;
    @MockBean
    protected MemberBusiness memberBusiness;
    @MockBean
    protected QnaBoardBusiness qnaBoardBusiness;

    private Member member;
```

따라서, MockBean을 주입하는 클래스를 따로 만들어 상속받아 사용하면 필드를 훨씬 적게 사용이 가능합니다.

**[ MemberControllerTest ]**
```java
@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@SuppressWarnings("NonAsciiCharacters")
@AutoConfigureMockMvc
@WebMvcTest(controllers = MemberController.class)
class MemberControllerTest extends MockBeanInjection {

    @Autowired
    private MockMvc mockMvc;

    @Autowired
    private ObjectMapper objectMapper;

	@MockBean
    private JwtUtil jwtUtil;
    @MockBean
    protected MemberService memberService;
    @MockBean
    protected MemberBusiness memberBusiness;
    @MockBean
    protected QnaBoardBusiness qnaBoardBusiness;

    private Member member;
```

**[ MockBeanInjection ]**
```java
@MockBean(JpaMetamodelMappingContext.class)
public class MockBeanInjection {
    @MockBean
    private JwtUtil jwtUtil;
    @MockBean
    protected MemberService memberService;
    @MockBean
    protected MemberBusiness memberBusiness;
    @MockBean
    protected QnaBoardBusiness qnaBoardBusiness;
}
```

## 🧲 참고 자료 및 공유 사항

[WithSecurityContext에 대해 알아보자](https://blogshine.tistory.com/627)
