### PR TITLE
test(Cart) Cart 테스트 코드 작성

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/Blueprint.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/Blueprint.java
@@ -104,7 +104,6 @@ public class Blueprint extends BaseEntity {
                      String secondCategory,
                      InspectionStatus inspectionStatus,
                      List<OrderBlueprint> orderBlueprints,
-                     List<CartBlueprint> cartBlueprints,
                      boolean isDeleted,
                      String detailImage) {
         this.id = id;
@@ -123,7 +122,6 @@ public class Blueprint extends BaseEntity {
         this.secondCategory = secondCategory;
         this.inspectionStatus = inspectionStatus;
         this.orderBlueprints = orderBlueprints;
-        this.cartBlueprints = cartBlueprints;
         this.isDeleted = isDeleted;
         this.detailImage = detailImage;
     }

--- a/server/src/main/java/com/onetool/server/api/cart/Cart.java
+++ b/server/src/main/java/com/onetool/server/api/cart/Cart.java
@@ -37,8 +37,9 @@ public class Cart extends BaseEntity {
         return new Cart(member);
     }
 
-    public void updateTotalPrice(Cart cart) {
-        this.totalPrice = this.getCartItems().stream()
+    public void updateTotalPrice() {
+        this.totalPrice = this.getCartItems()
+                .stream()
                 .mapToLong(item -> item.getBlueprint().getStandardPrice())
                 .sum();
     }

--- a/server/src/main/java/com/onetool/server/api/cart/CartBlueprint.java
+++ b/server/src/main/java/com/onetool/server/api/cart/CartBlueprint.java
@@ -46,4 +46,11 @@ public class CartBlueprint extends BaseEntity {
         this.blueprint = blueprint;
         blueprint.getCartBlueprints().add(this);
     }
+
+    public void deleteCartBlueprint(){
+        cart.getCartItems().remove(this);
+        this.cart = null;
+        blueprint.getCartBlueprints().remove(this);
+        this.blueprint = null;
+    }
 }

--- a/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
@@ -28,7 +28,6 @@ public class CartBusiness {
         Blueprint blueprint = blueprintService.findBlueprintById(blueprintId);
         Cart cart = memberWithCart.getCart();
         cartService.saveCart(cart, blueprint);
-        cart.updateTotalPrice();
     }
 
     @Transactional(readOnly = true)
@@ -45,8 +44,7 @@ public class CartBusiness {
         Member member = memberService.findOneWithCart(userId);
         Cart cart = member.getCart();
         CartBlueprint cartBlueprint = cartService.findCartBlueprint(cart, blueprintId);
-        cartService.deleteCartBlueprint(cartBlueprint);
-        cart.updateTotalPrice();
+        cartService.deleteCartBlueprint(cart, cartBlueprint);
         return "삭제되었습니다";
     }
 }

--- a/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
@@ -6,28 +6,22 @@ import com.onetool.server.api.cart.Cart;
 import com.onetool.server.api.cart.CartBlueprint;
 import com.onetool.server.api.cart.dto.response.CartItemsResponse;
 import com.onetool.server.api.cart.service.CartService;
-import com.onetool.server.api.member.domain.Member;
-import com.onetool.server.api.member.service.MemberService;
 import com.onetool.server.global.annotation.Business;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Business
 @RequiredArgsConstructor
 public class CartBusiness {
 
     private final CartService cartService;
-    private final MemberService memberService;
     private final BlueprintService blueprintService;
 
     @Transactional
     public void addBlueprintToCart(Long userId, Long blueprintId) {
-        Member memberWithCart = memberService.findOneWithCart(userId);
+        Cart memberCart = cartService.findCartById(userId);
         Blueprint blueprint = blueprintService.findBlueprintById(blueprintId);
-        Cart cart = memberWithCart.getCart();
-        cartService.saveCart(cart, blueprint);
+        cartService.saveCart(memberCart, blueprint);
     }
 
     @Transactional(readOnly = true)
@@ -41,10 +35,9 @@ public class CartBusiness {
 
     @Transactional
     public String removeBlueprintInCart(Long userId, Long blueprintId) {
-        Member member = memberService.findOneWithCart(userId);
-        Cart cart = member.getCart();
-        CartBlueprint cartBlueprint = cartService.findCartBlueprint(cart, blueprintId);
-        cartService.deleteCartBlueprint(cart, cartBlueprint);
+        Cart memberCart = cartService.findCartById(userId);
+        CartBlueprint cartBlueprint = cartService.findCartBlueprint(memberCart, blueprintId);
+        cartService.deleteCartBlueprint(memberCart, cartBlueprint);
         return "삭제되었습니다";
     }
 }

--- a/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
@@ -9,8 +9,6 @@ import com.onetool.server.api.cart.service.CartService;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.service.MemberService;
 import com.onetool.server.global.annotation.Business;
-import com.onetool.server.global.new_exception.exception.ApiException;
-import com.onetool.server.global.new_exception.exception.error.CartErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +27,6 @@ public class CartBusiness {
         Member memberWithCart = memberService.findOneWithCart(userId);
         Blueprint blueprint = blueprintService.findBlueprintById(blueprintId);
         Cart cart = memberWithCart.getCart();
-        cartService.validateBlueprintAlreadyInCart(cart, blueprint);
         cartService.saveCart(cart, blueprint);
         cart.updateTotalPrice();
     }
@@ -47,16 +44,9 @@ public class CartBusiness {
     public String removeBlueprintInCart(Long userId, Long blueprintId) {
         Member member = memberService.findOneWithCart(userId);
         Cart cart = member.getCart();
-        CartBlueprint cartBlueprint = findCartBlueprint(cart, blueprintId);
+        CartBlueprint cartBlueprint = cartService.findCartBlueprint(cart, blueprintId);
         cartService.deleteCartBlueprint(cartBlueprint);
         cart.updateTotalPrice();
         return "삭제되었습니다";
-    }
-
-    private CartBlueprint findCartBlueprint(Cart cart, Long blueprintId) {
-        return cart.getCartItems().stream()
-                .filter(cartItem -> cartItem.getBlueprint().getId().equals(blueprintId))
-                .findFirst()
-                .orElseThrow(() -> new ApiException(CartErrorCode.NOT_FOUND_ERROR, "해당하는 Cart에 bluePrintId와 일치하는 Cart가 존재하지 않습니다. cartId : " + cart.getId() + "blueprintId : " + blueprintId));
     }
 }

--- a/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/cart/business/CartBusiness.java
@@ -31,17 +31,16 @@ public class CartBusiness {
         Cart cart = memberWithCart.getCart();
         cartService.validateBlueprintAlreadyInCart(cart, blueprint);
         cartService.saveCart(cart, blueprint);
-        cart.updateTotalPrice(cart);
+        cart.updateTotalPrice();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Object getMyCart(Long userId) {
         Cart cart = cartService.findCartById(userId);
-        Long totalPrice = cartService.findTotalPrice(cart.getId());
-        List<CartBlueprint> cartBlueprintList = cartService.findCartBlueprint(cart.getId());
-
-        if (cartBlueprintList == null) return "장바구니가 비었습니다.";
-        return CartItemsResponse.cartItems(totalPrice, cartBlueprintList);
+        if (cart.getCartItems().isEmpty()){
+            return "장바구니가 비었습니다.";
+        }
+        return CartItemsResponse.from(cart);
     }
 
     @Transactional
@@ -50,8 +49,7 @@ public class CartBusiness {
         Cart cart = member.getCart();
         CartBlueprint cartBlueprint = findCartBlueprint(cart, blueprintId);
         cartService.deleteCartBlueprint(cartBlueprint);
-        cart.updateTotalPrice(cart);
-
+        cart.updateTotalPrice();
         return "삭제되었습니다";
     }
 

--- a/server/src/main/java/com/onetool/server/api/cart/controller/CartController.java
+++ b/server/src/main/java/com/onetool/server/api/cart/controller/CartController.java
@@ -10,25 +10,26 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/cart")
 public class CartController {
 
     private final CartBusiness cartBusiness;
 
-    @PostMapping("/api/cart/add/{blueprintId}")
+    @PostMapping("/{blueprintId}")
     public ApiResponse<String> addBlueprintToCart(@AuthenticationPrincipal PrincipalDetails principal,
-                                                  @PathVariable(name = "blueprintId") Long blueprintId) {
+                                                  @PathVariable Long blueprintId) {
         cartBusiness.addBlueprintToCart(principal.getContext().getId(), blueprintId);
         return ApiResponse.onSuccess("장바구니에 상품이 등록 되었습니다.");
     }
 
-    @GetMapping("/cart")
+    @GetMapping
     public ApiResponse<Object> showMyCart(@AuthenticationPrincipal PrincipalDetails principal) {
         return ApiResponse.onSuccess(cartBusiness.getMyCart(principal.getContext().getId()));
     }
 
-    @DeleteMapping("/api/cart/delete/{blueprintId}")
+    @DeleteMapping("/{blueprintId}")
     public ApiResponse<String> deleteBlueprintInCart(@AuthenticationPrincipal PrincipalDetails principal,
-                                                     @PathVariable(name = "blueprintId") Long blueprintId) {
+                                                     @PathVariable Long blueprintId) {
         return ApiResponse.onSuccess(cartBusiness.removeBlueprintInCart(principal.getContext().getId(), blueprintId));
     }
 }

--- a/server/src/main/java/com/onetool/server/api/cart/dto/request/AddBlueprintToCartRequest.java
+++ b/server/src/main/java/com/onetool/server/api/cart/dto/request/AddBlueprintToCartRequest.java
@@ -1,8 +1,0 @@
-package com.onetool.server.api.cart.dto.request;
-
-import jakarta.validation.constraints.NotNull;
-
-public record AddBlueprintToCartRequest(
-        @NotNull Long blueprintId
-) {
-}

--- a/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemResponse.java
+++ b/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemResponse.java
@@ -1,0 +1,25 @@
+package com.onetool.server.api.cart.dto.response;
+
+import com.onetool.server.api.cart.CartBlueprint;
+import lombok.Builder;
+
+@Builder
+public record CartItemResponse(
+        Long blueprintId,
+        String blueprintName,
+        String extension,
+        String author,
+        Long standardPrice,
+        Long salesPrice
+) {
+    public static CartItemResponse from(CartBlueprint cartBlueprint) {
+        return CartItemResponse.builder()
+                .blueprintId(cartBlueprint.getId())
+                .blueprintName(cartBlueprint.getBlueprint().getBlueprintName())
+                .extension(cartBlueprint.getBlueprint().getExtension())
+                .author(cartBlueprint.getBlueprint().getCreatorName())
+                .standardPrice(cartBlueprint.getBlueprint().getStandardPrice())
+                .salesPrice(cartBlueprint.getBlueprint().getSalePrice())
+                .build();
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemResponse.java
+++ b/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemResponse.java
@@ -1,25 +1,24 @@
 package com.onetool.server.api.cart.dto.response;
 
+import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.cart.CartBlueprint;
 import lombok.Builder;
 
 @Builder
 public record CartItemResponse(
-        Long blueprintId,
         String blueprintName,
         String extension,
         String author,
         Long standardPrice,
         Long salesPrice
 ) {
-    public static CartItemResponse from(CartBlueprint cartBlueprint) {
+    public static CartItemResponse from(Blueprint blueprint) {
         return CartItemResponse.builder()
-                .blueprintId(cartBlueprint.getId())
-                .blueprintName(cartBlueprint.getBlueprint().getBlueprintName())
-                .extension(cartBlueprint.getBlueprint().getExtension())
-                .author(cartBlueprint.getBlueprint().getCreatorName())
-                .standardPrice(cartBlueprint.getBlueprint().getStandardPrice())
-                .salesPrice(cartBlueprint.getBlueprint().getSalePrice())
+                .blueprintName(blueprint.getBlueprintName())
+                .extension(blueprint.getExtension())
+                .author(blueprint.getCreatorName())
+                .standardPrice(blueprint.getStandardPrice())
+                .salesPrice(blueprint.getSalePrice())
                 .build();
     }
 }

--- a/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemsResponse.java
+++ b/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemsResponse.java
@@ -1,6 +1,7 @@
 package com.onetool.server.api.cart.dto.response;
 
 import com.onetool.server.api.blueprint.dto.response.BlueprintResponse;
+import com.onetool.server.api.cart.Cart;
 import com.onetool.server.api.cart.CartBlueprint;
 import com.onetool.server.api.cart.dto.CartResponse;
 import lombok.Builder;
@@ -10,13 +11,13 @@ import java.util.List;
 @Builder
 public record CartItemsResponse(
         Long totalPrice,
-        List<BlueprintResponse> blueprintsInCart
+        List<CartItemResponse> blueprintsInCart
 ) {
-    public static CartItemsResponse cartItems(Long totalPrice, List<CartBlueprint> cartBlueprints) {
+    public static CartItemsResponse from(Cart cart) {
         return CartItemsResponse.builder()
-                .totalPrice(totalPrice)
-                .blueprintsInCart(cartBlueprints.stream()
-                        .map(cartItem -> BlueprintResponse.items(cartItem.getBlueprint()))
+                .totalPrice(cart.getTotalPrice())
+                .blueprintsInCart(cart.getCartItems().stream()
+                        .map(CartItemResponse::from)
                         .toList())
                 .build();
     }

--- a/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemsResponse.java
+++ b/server/src/main/java/com/onetool/server/api/cart/dto/response/CartItemsResponse.java
@@ -17,7 +17,7 @@ public record CartItemsResponse(
         return CartItemsResponse.builder()
                 .totalPrice(cart.getTotalPrice())
                 .blueprintsInCart(cart.getCartItems().stream()
-                        .map(CartItemResponse::from)
+                        .map(cartBlueprint -> CartItemResponse.from(cartBlueprint.getBlueprint()))
                         .toList())
                 .build();
     }

--- a/server/src/main/java/com/onetool/server/api/cart/service/CartService.java
+++ b/server/src/main/java/com/onetool/server/api/cart/service/CartService.java
@@ -14,6 +14,7 @@ import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,8 +25,6 @@ import static com.onetool.server.global.exception.codes.ErrorCode.*;
 @RequiredArgsConstructor
 public class CartService {
 
-    @PersistenceContext
-    private final EntityManager entityManager;
     private final CartRepository cartRepository;
     private final CartBlueprintRepository cartBlueprintRepository;
 
@@ -34,26 +33,15 @@ public class CartService {
                 .orElseThrow(() -> new ApiException(CartErrorCode.NOT_FOUND_ERROR,"유저와 관련된 Cart가 없습니다. userId : "+ userId));
     }
 
-    public Long findTotalPrice(Long cartId) {
-        return cartRepository.findTotalPriceByCartId(cartId);
-    }
-
-    public List<CartBlueprint> findCartBlueprint(Long cartId) {
-        return cartRepository.findCartBlueprintsByCartId(cartId);
-    }
-
     public void saveCart(Cart cart, Blueprint blueprint) {
         CartBlueprint cartBlueprint = CartBlueprint.create(cart, blueprint);
-
         cartBlueprintRepository.save(cartBlueprint);
-        entityManager.flush(); //todo test필요
     }
 
     public void deleteCartBlueprint(CartBlueprint cartBlueprint) {
         if (cartBlueprint == null) throw new ApiException(CartErrorCode.NULL_POINT_ERROR,"CartBlueprint가 NULL입니다");
 
         cartBlueprintRepository.deleteById(cartBlueprint.getId());
-        entityManager.flush(); //todo test필요
     }
 
     public void validateBlueprintAlreadyInCart(Cart cart, Blueprint blueprint) {

--- a/server/src/main/java/com/onetool/server/api/cart/service/CartService.java
+++ b/server/src/main/java/com/onetool/server/api/cart/service/CartService.java
@@ -5,20 +5,13 @@ import com.onetool.server.api.cart.Cart;
 import com.onetool.server.api.cart.CartBlueprint;
 import com.onetool.server.api.cart.repository.CartBlueprintRepository;
 import com.onetool.server.api.cart.repository.CartRepository;
-import com.onetool.server.global.exception.CartNotFoundException;
-import com.onetool.server.global.exception.base.BaseException;
 import com.onetool.server.global.new_exception.exception.ApiException;
 import com.onetool.server.global.new_exception.exception.error.CartErrorCode;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
-import static com.onetool.server.global.exception.codes.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -30,22 +23,45 @@ public class CartService {
 
     public Cart findCartById(Long userId) {
         return cartRepository.findCartWithMemberByMemberId(userId)
-                .orElseThrow(() -> new ApiException(CartErrorCode.NOT_FOUND_ERROR,"유저와 관련된 Cart가 없습니다. userId : "+ userId));
+                .orElseThrow(() -> new ApiException(CartErrorCode.NOT_FOUND_ERROR,
+                        "유저와 관련된 Cart가 없습니다. userId : "
+                                + userId
+                        )
+                );
     }
 
     public void saveCart(Cart cart, Blueprint blueprint) {
+        validateBlueprintAlreadyInCart(cart, blueprint.getId());
         CartBlueprint cartBlueprint = CartBlueprint.create(cart, blueprint);
         cartBlueprintRepository.save(cartBlueprint);
     }
 
     public void deleteCartBlueprint(CartBlueprint cartBlueprint) {
-        if (cartBlueprint == null) throw new ApiException(CartErrorCode.NULL_POINT_ERROR,"CartBlueprint가 NULL입니다");
-
+        if (cartBlueprint == null) {
+            throw new ApiException(CartErrorCode.NULL_POINT_ERROR, "CartBlueprint가 NULL입니다");
+        }
         cartBlueprintRepository.deleteById(cartBlueprint.getId());
     }
 
-    public void validateBlueprintAlreadyInCart(Cart cart, Blueprint blueprint) {
-        if (cartBlueprintRepository.existsByCartAndBlueprint(cart, blueprint))
-            throw new ApiException(CartErrorCode.ALREADY_EXIST_BLUEPRINT_IN_CART);
+    private void validateBlueprintAlreadyInCart(Cart cart, Long blueprintId) {
+       if(cart.getCartItems()
+               .stream()
+               .anyMatch(cartBlueprint -> cartBlueprint.getBlueprint().getId().equals(blueprintId))) {
+           throw new ApiException(CartErrorCode.ALREADY_EXIST_BLUEPRINT_IN_CART);
+       }
+    }
+
+    public CartBlueprint findCartBlueprint(Cart cart, Long blueprintId) {
+        return cart.getCartItems()
+                .stream()
+                .filter(cartItem -> cartItem.getBlueprint().getId().equals(blueprintId))
+                .findFirst()
+                .orElseThrow(() -> new ApiException(CartErrorCode.NOT_FOUND_ERROR,
+                        "해당하는 Cart에 bluePrintId와 일치하는 Cart가 존재하지 않습니다. cartId : "
+                                + cart.getId()
+                                + "blueprintId : "
+                                + blueprintId
+                        )
+                );
     }
 }

--- a/server/src/main/java/com/onetool/server/api/cart/service/CartService.java
+++ b/server/src/main/java/com/onetool/server/api/cart/service/CartService.java
@@ -34,13 +34,16 @@ public class CartService {
         validateBlueprintAlreadyInCart(cart, blueprint.getId());
         CartBlueprint cartBlueprint = CartBlueprint.create(cart, blueprint);
         cartBlueprintRepository.save(cartBlueprint);
+        cart.updateTotalPrice();
     }
 
-    public void deleteCartBlueprint(CartBlueprint cartBlueprint) {
+    public void deleteCartBlueprint(Cart cart, CartBlueprint cartBlueprint) {
         if (cartBlueprint == null) {
             throw new ApiException(CartErrorCode.NULL_POINT_ERROR, "CartBlueprint가 NULL입니다");
         }
         cartBlueprintRepository.deleteById(cartBlueprint.getId());
+        cartBlueprint.deleteCartBlueprint();
+        cart.updateTotalPrice();
     }
 
     private void validateBlueprintAlreadyInCart(Cart cart, Long blueprintId) {

--- a/server/src/test/java/com/onetool/server/api/cart/business/CartBusinessTest.java
+++ b/server/src/test/java/com/onetool/server/api/cart/business/CartBusinessTest.java
@@ -10,9 +10,6 @@ import com.onetool.server.api.cart.fixture.CartFixture;
 import com.onetool.server.api.cart.service.CartService;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.fixture.MemberFixture;
-import com.onetool.server.api.member.service.MemberService;
-import com.onetool.server.global.new_exception.exception.ApiException;
-import com.onetool.server.global.new_exception.exception.error.CartErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,9 +32,6 @@ public class CartBusinessTest {
     private CartService cartService;
 
     @Mock
-    private MemberService memberService;
-
-    @Mock
     private BlueprintService blueprintService;
 
     @InjectMocks
@@ -57,7 +51,7 @@ public class CartBusinessTest {
     @Test
     void 장바구니에_도면_추가_성공(){
         //given
-        given(memberService.findOneWithCart(anyLong())).willReturn(member);
+        given(cartService.findCartById(anyLong())).willReturn(cart);
         given(blueprintService.findBlueprintById(anyLong())).willReturn(blueprint);
 
         //when
@@ -98,7 +92,7 @@ public class CartBusinessTest {
     @Test
     void 장바구니_도면_삭제_성공(){
         //given
-        given(memberService.findOneWithCart(anyLong())).willReturn(member);
+        given(cartService.findCartById(anyLong())).willReturn(cart);
         given(cartService.findCartBlueprint(any(Cart.class), anyLong()))
                 .willReturn(CartBlueprint.builder().build());
         doNothing().when(cartService).deleteCartBlueprint(any(Cart.class), any(CartBlueprint.class));

--- a/server/src/test/java/com/onetool/server/api/cart/business/CartBusinessTest.java
+++ b/server/src/test/java/com/onetool/server/api/cart/business/CartBusinessTest.java
@@ -1,0 +1,135 @@
+package com.onetool.server.api.cart.business;
+
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.blueprint.service.BlueprintService;
+import com.onetool.server.api.cart.Cart;
+import com.onetool.server.api.cart.CartBlueprint;
+import com.onetool.server.api.cart.dto.response.CartItemResponse;
+import com.onetool.server.api.cart.dto.response.CartItemsResponse;
+import com.onetool.server.api.cart.fixture.CartFixture;
+import com.onetool.server.api.cart.service.CartService;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.service.MemberService;
+import com.onetool.server.global.new_exception.exception.ApiException;
+import com.onetool.server.global.new_exception.exception.error.CartErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+public class CartBusinessTest {
+    @Mock
+    private CartService cartService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private BlueprintService blueprintService;
+
+    @InjectMocks
+    private CartBusiness cartBusiness;
+
+    private Member member;
+    private Blueprint blueprint;
+    private Cart cart;
+
+    @BeforeEach
+    public void setUp() {
+        member = CartFixture.createMemberWithCart();
+        blueprint = CartFixture.createBlueprintToAddInCart();
+        cart = member.getCart();
+    }
+
+    @Test
+    void 장바구니에_도면_추가_성공(){
+        //given
+        given(memberService.findOneWithCart(anyLong())).willReturn(member);
+        given(blueprintService.findBlueprintById(anyLong())).willReturn(blueprint);
+        doAnswer(invocation -> {
+            Cart cartArg = invocation.getArgument(0);
+            Blueprint blueprintArg = invocation.getArgument(1);
+            cartArg.getCartItems().add(new CartBlueprint(cartArg, blueprintArg));
+            return null;
+        }).when(cartService).saveCart(any(Cart.class), any(Blueprint.class));
+        int beforeSize = cart.getCartItems().size();
+
+        //when
+        cartBusiness.addBlueprintToCart(member.getId(), blueprint.getId());
+
+        //then
+        verify(cartService).saveCart(any(Cart.class), any(Blueprint.class));
+        assertThat(cart.getCartItems())
+                .hasSize(beforeSize + 1);
+        assertThat(cart.getCartItems())
+                .extracting("blueprint")
+                .contains(blueprint);
+        assertThat(cart.getTotalPrice())
+                .isEqualTo(40000L);
+    }
+
+    @Test
+    void 장바구니_조회_성공(){
+        //given
+        given(cartService.findCartById(anyLong())).willReturn(cart);
+
+        //when
+        CartBlueprint.create(cart, blueprint);
+        CartItemsResponse result = (CartItemsResponse) cartBusiness.getMyCart(member.getId());
+
+        //then
+        assertThat(result.totalPrice())
+                .isEqualTo(cart.getTotalPrice());
+
+        assertThat(result.blueprintsInCart())
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(CartItemResponse.from(blueprint)));
+    }
+
+    @Test
+    void 장바구니_비어있음_성공(){
+        //given
+        given(cartService.findCartById(anyLong())).willReturn(cart);
+
+        //when & then
+        assertThat((String) cartBusiness.getMyCart(member.getId()))
+                .isEqualTo("장바구니가 비었습니다.");
+    }
+
+    @Test
+    void 장바구니_도면_삭제_성공(){
+        //given
+        CartBlueprint cartBlueprint = CartBlueprint.create(cart, blueprint);
+        given(memberService.findOneWithCart(anyLong())).willReturn(member);
+        given(cartService.findCartBlueprint(any(Cart.class), anyLong()))
+                .willReturn(cartBlueprint);
+        doAnswer(invocation -> {
+            CartBlueprint cbArgs = invocation.getArgument(0);
+            cart.getCartItems().remove(cbArgs);
+            return null;
+        }).when(cartService).deleteCartBlueprint(any(CartBlueprint.class));
+
+        // when
+        String result = cartBusiness.removeBlueprintInCart(member.getId(), blueprint.getId());
+
+        // then
+        assertThat(result).isEqualTo("삭제되었습니다");
+        assertThat(member.getCart().getCartItems())
+                .doesNotContain(cartBlueprint);
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/cart/controller/CartControllerTest.java
+++ b/server/src/test/java/com/onetool/server/api/cart/controller/CartControllerTest.java
@@ -1,0 +1,118 @@
+package com.onetool.server.api.cart.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.cart.Cart;
+import com.onetool.server.api.cart.business.CartBusiness;
+import com.onetool.server.api.cart.dto.response.CartItemsResponse;
+import com.onetool.server.api.cart.fixture.CartFixture;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.fixture.MemberFixture;
+import com.onetool.server.api.member.fixture.WithMockPrincipalDetails;
+import com.onetool.server.global.auth.jwt.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureMockMvc
+@WebMvcTest(controllers = CartController.class)
+public class CartControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CartBusiness cartBusiness;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    private Member member;
+
+    private final String cartEndpointPrefix = "/api/cart";
+
+    @BeforeEach
+    void setUp(){
+        member = MemberFixture.createMember();
+    }
+
+    @Test
+    @WithMockPrincipalDetails
+    void 장바구니_도면_추가_성공() throws Exception {
+        //given
+        long blueprintId = 1L;
+
+        //when & then
+        mockMvc.perform(post(cartEndpointPrefix + "/{blueprintId}", blueprintId)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("장바구니에 상품이 등록 되었습니다."));
+    }
+
+    @Test
+    @WithMockPrincipalDetails
+    void 장바구니_조회_성공() throws Exception {
+        //given
+        List<Blueprint> blueprints = CartFixture.createBlueprints();
+        Cart cart = member.getCart();
+        CartFixture.createCartBlueprints(cart, blueprints);
+        CartItemsResponse response = CartItemsResponse.from(cart);
+        given(cartBusiness.getMyCart(anyLong())).willReturn(response);
+
+
+        //when & then
+        mockMvc.perform(get(cartEndpointPrefix)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.totalPrice").value(cart.getTotalPrice()))
+                .andExpect(jsonPath("$.result.blueprintsInCart[0].blueprintName")
+                        .value(response.blueprintsInCart().get(0).blueprintName()))
+                .andExpect(jsonPath("$.result.blueprintsInCart[1].blueprintName")
+                        .value(response.blueprintsInCart().get(1).blueprintName()))
+                .andExpect(jsonPath("$.result.blueprintsInCart[2].blueprintName")
+                        .value(response.blueprintsInCart().get(2).blueprintName()));
+    }
+
+    @Test
+    @WithMockPrincipalDetails
+    void 장바구니_비어있음_조회_성공() throws Exception {
+        //given
+        String cartEmpty = "장바구니가 비어있습니다.";
+        given(cartBusiness.getMyCart(anyLong())).willReturn(cartEmpty);
+
+        //when & then
+        mockMvc.perform(get(cartEndpointPrefix)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("장바구니가 비어있습니다."));
+
+    }
+
+    @Test
+    @WithMockPrincipalDetails
+    void 장바구니_도면_삭제_성공() throws Exception {
+        //given
+        String deleteMessage = "삭제되었습니다";
+        given(cartBusiness.removeBlueprintInCart(anyLong(), anyLong())).willReturn(deleteMessage);
+
+        //when & then
+        mockMvc.perform(delete(cartEndpointPrefix + "/{blueprintId}", 1L)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("삭제되었습니다"));
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/cart/fixture/CartFixture.java
+++ b/server/src/test/java/com/onetool/server/api/cart/fixture/CartFixture.java
@@ -4,14 +4,23 @@ import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.cart.Cart;
 import com.onetool.server.api.cart.CartBlueprint;
 import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.enums.UserRole;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class CartFixture {
 
-    public static Member createCartMember() {
+    public static Member createMemberWithCart() {
         return Member.builder()
+                .id(1L)
+                .name("이동훈")
+                .email("test@example.com")
+                .role(UserRole.ROLE_USER)
+                .phoneNum("01012345678")
+                .field("BACKEND")
+                .isNative(true)
+                .cart(null)
                 .build();
     }
 

--- a/server/src/test/java/com/onetool/server/api/cart/fixture/CartFixture.java
+++ b/server/src/test/java/com/onetool/server/api/cart/fixture/CartFixture.java
@@ -1,0 +1,76 @@
+package com.onetool.server.api.cart.fixture;
+
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.cart.Cart;
+import com.onetool.server.api.cart.CartBlueprint;
+import com.onetool.server.api.member.domain.Member;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CartFixture {
+
+    public static Member createCartMember() {
+        return Member.builder()
+                .build();
+    }
+
+    public static Cart createCartWithNoMember() {
+        return Cart.createCart(
+                Member.builder()
+                .build()
+        );
+    }
+
+    public static List<Blueprint> createBlueprints(){
+        List<Blueprint> blueprints = new ArrayList<>();
+        blueprints.add(
+                Blueprint.builder()
+                        .id(1L)
+                        .blueprintName("test blueprint 1")
+                        .extension("test extension 1")
+                        .creatorName("test creator 1")
+                        .standardPrice(10000L)
+                        .salePrice(2000L)
+                        .build()
+        );
+        blueprints.add(
+                Blueprint.builder()
+                        .id(2L)
+                        .blueprintName("test blueprint 2")
+                        .extension("test extension 2")
+                        .creatorName("test creator 2")
+                        .standardPrice(20000L)
+                        .salePrice(3000L)
+                        .build()
+        );
+        blueprints.add(
+                Blueprint.builder()
+                        .id(3L)
+                        .blueprintName("test blueprint 3")
+                        .extension("test extension 3")
+                        .creatorName("test creator 3")
+                        .standardPrice(30000L)
+                        .salePrice(4000L)
+                        .build()
+        );
+        return blueprints;
+    }
+
+    public static Blueprint createBlueprintToAddInCart(){
+        return Blueprint.builder()
+                .id(4L)
+                .blueprintName("test blueprint 4")
+                .extension("test extension 4")
+                .creatorName("test creator 4")
+                .standardPrice(40000L)
+                .salePrice(5000L)
+                .build();
+    }
+
+    public static void createCartBlueprints(Cart cart, List<Blueprint> blueprints) {
+        for (Blueprint blueprint : blueprints) {
+            CartBlueprint.create(cart, blueprint);
+        }
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/cart/fixture/CartFixture.java
+++ b/server/src/test/java/com/onetool/server/api/cart/fixture/CartFixture.java
@@ -66,7 +66,7 @@ public class CartFixture {
         return blueprints;
     }
 
-    public static Blueprint createBlueprintToAddInCart(){
+    public static Blueprint createBlueprint(){
         return Blueprint.builder()
                 .id(4L)
                 .blueprintName("test blueprint 4")

--- a/server/src/test/java/com/onetool/server/api/cart/service/CartServiceTest.java
+++ b/server/src/test/java/com/onetool/server/api/cart/service/CartServiceTest.java
@@ -1,0 +1,116 @@
+package com.onetool.server.api.cart.service;
+
+
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.cart.Cart;
+import com.onetool.server.api.cart.CartBlueprint;
+import com.onetool.server.api.cart.fixture.CartFixture;
+import com.onetool.server.api.cart.repository.CartBlueprintRepository;
+import com.onetool.server.api.cart.repository.CartRepository;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.global.new_exception.exception.ApiException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+public class CartServiceTest {
+
+    @Mock
+    private CartRepository cartRepository;
+
+    @Mock
+    private CartBlueprintRepository cartBlueprintRepository;
+
+    @InjectMocks
+    private CartService cartService;
+
+    private Cart cart;
+
+    @BeforeEach
+    public void setUp() {
+        cart = CartFixture.createCartWithNoMember();
+        List<Blueprint> blueprints = CartFixture.createBlueprints();
+        CartFixture.createCartBlueprints(cart, blueprints);
+    }
+
+    @Test
+    void 장바구니_id_조회_성공(){
+        //given
+        // cartRepository에서 memberId로 장바구니를 조회해오면 Fixture를 통해 미리 만들어놓은 Cart를 불러오도록 Stub(스텁)
+        given(cartRepository.findCartWithMemberByMemberId(anyLong()))
+                .willReturn(Optional.of(cart));
+
+        //when
+        Cart result = cartService.findCartById(anyLong());
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(cart);
+        verify(cartRepository, times(1)).findCartWithMemberByMemberId(anyLong());
+    }
+
+    @Test
+    void 장바구니_id_조회_실패(){
+        ///given
+        given(cartRepository.findCartWithMemberByMemberId(anyLong()))
+                .willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(()-> cartService.findCartById(anyLong()))
+                .isInstanceOf(ApiException.class);
+    }
+
+    @Test
+    void 장바구니_도면_추가_성공() {
+        //given
+        Blueprint newBlueprintToAddInCart = CartFixture.createBlueprintToAddInCart();
+
+        //when
+        cartService.saveCart(cart, newBlueprintToAddInCart);
+
+        //then
+        verify(cartBlueprintRepository, times(1)).save(any(CartBlueprint.class));
+    }
+
+    @Test
+    void 장바구니_도면_삭제_성공(){
+        //given
+        CartBlueprint cartBlueprint = CartBlueprint.builder().build();
+
+        //when
+        cartService.deleteCartBlueprint(cartBlueprint);
+
+        // then
+        verify(cartBlueprintRepository, times(1)).deleteById(cartBlueprint.getId());
+    }
+
+    @Test
+    void 장바구니_도면_삭졔_실패(){
+        // Given
+        CartBlueprint cartBlueprint = null;
+
+        // When & Then
+        // 현재 ApiException 인스턴스를 만들 떄 커스텀 에러 메세지를 에러 메세지로 초기화하지 않아 예외 발생 여부만 확인
+        // TODO : 커스텀 메세지까지 확인
+        assertThatThrownBy(() -> cartService.deleteCartBlueprint(cartBlueprint))
+                .isInstanceOf(ApiException.class);
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/cart/service/CartServiceTest.java
+++ b/server/src/test/java/com/onetool/server/api/cart/service/CartServiceTest.java
@@ -54,7 +54,6 @@ public class CartServiceTest {
     @Test
     void 장바구니_id_조회_성공(){
         //given
-        // cartRepository에서 memberId로 장바구니를 조회해오면 Fixture를 통해 미리 만들어놓은 Cart를 불러오도록 Stub(스텁)
         given(cartRepository.findCartWithMemberByMemberId(anyLong()))
                 .willReturn(Optional.of(cart));
 
@@ -88,6 +87,17 @@ public class CartServiceTest {
 
         //then
         verify(cartBlueprintRepository, times(1)).save(any(CartBlueprint.class));
+    }
+
+    @Test
+    void 장바구니_도면_추가_실패() {
+        //given
+        Blueprint newBlueprintToAddInCart = CartFixture.createBlueprintToAddInCart();
+        cart.getCartItems().add(new CartBlueprint(cart, newBlueprintToAddInCart));
+
+        // when & then
+        assertThatThrownBy(() -> cartService.saveCart(cart, newBlueprintToAddInCart))
+                .isInstanceOf(ApiException.class);
     }
 
     @Test

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  jpa:
+    database: h2
+    properties.hibernate.dialect: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+logging:
+  level:
+    root: info
+    org:
+      hibernate:
+        type: trace

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
## #️⃣ 이슈

- #212 


## 🔎 작업 내용

테스트용 데이터베이스 설정파일을 추가했습니다.

각 테스트 클래스마다 
`@ActiveProfiles("test")
`
를 정의해주시면 모든 테스트는 테스트 디렉토리 안에 있는 application-test.yml 설정이 활성화 됩니다. 

# Test

## CartServiceTest
```
@ExtendWith(MockitoExtension.class)
@ActiveProfiles("test")
@SuppressWarnings("NonAsciiCharacters")
public class CartServiceTest {

    @Mock
    private CartRepository cartRepository;

    @Mock
    private CartBlueprintRepository cartBlueprintRepository;

    @InjectMocks
    private CartService cartService;

```
- @ActiveProfiles("test")가 적용되어 테스트 환경 설정(application-test.yml)을 로드
- Mock으로 생성된 cartRepository, cartBlueprintRepository를 CartService에 자동으로 주입
- @Mock을 활용해 실제 데이터베이스에 접근하지 않고, 테스트에서 원하는 동작을 시뮬레이션 가능

## CartFixture
Cart - CartBlueprint - Blueprint가 연관관계에 있는 상태이므로
테스트 환경에서는 엔티티 간의 연관관계를 유지하면서도 독립적이고 재사용 가능한 Fixture를 생성
즉, Cart를 생성할 때 CartBlueprint와 Blueprint도 함께 생성되도록 설계


# Refactor

## CartController
- 엔드포인트 중 'add', 'delete' 동사 삭제 : REST API에서 HTTP 메서드가 자원에 대한 행위를 명시함, 동사 사용하지 않음
## CartBusiness
- validation과 엔티티의 update작업을 모두 service에서 진행하도록 변경
## CartService
- 엔티티의 필드를 변경하는 메서드는 service에서 진행
- 엔티티간의 연관관계 맺음/끊음 메서드 사용


# 고민해야 할 점
```
@Transactional(readOnly = true)
    public Object getMyCart(Long userId) {
        Cart cart = cartService.findCartById(userId);
        if (cart.getCartItems().isEmpty()){
            return "장바구니가 비었습니다.";
        }
        return CartItemsResponse.from(cart);
    }
```
현재 이 로직은 반환형이 Object 입니다. Object보단 특정 반환형을 지정해주는게 좋아보이는데,
@mete0rfish , @PlusUltraCode 의 의견이 궁금합니다.
