### PR TITLE
feat(Orders): orders N+1문제 해결 2010 쿼리 -> 13개 쿼리 => 캐시 적용

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -74,6 +74,10 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.6.RELEASE'
+
+	//redis createdAt 직렬화
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/onetool/server/api/blueprint/Blueprint.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/Blueprint.java
@@ -1,5 +1,6 @@
 package com.onetool.server.api.blueprint;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.onetool.server.api.blueprint.dto.request.BlueprintRequest;
 import com.onetool.server.api.blueprint.dto.response.BlueprintResponse;
 import com.onetool.server.api.cart.CartBlueprint;
@@ -75,9 +76,11 @@ public class Blueprint extends BaseEntity {
     private InspectionStatus inspectionStatus;
 
     @OneToMany(mappedBy = "blueprint")
+    @JsonIgnore
     private List<OrderBlueprint> orderBlueprints = new ArrayList<>();
 
     @OneToMany(mappedBy = "blueprint")
+    @JsonIgnore
     private List<CartBlueprint> cartBlueprints = new ArrayList<>();
 
     @Column(name = "is_deleted", nullable = false)

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
@@ -31,6 +31,11 @@ public class BlueprintService {
         return blueprintList;
     }
 
+    public List<Blueprint> findAll(){
+        List<Blueprint> blueprintList = blueprintRepository.findAll();
+        return blueprintList;
+    }
+
     public Blueprint findBlueprintById(Long blueprintId) {
         return blueprintRepository.findById(blueprintId)
                 .orElseThrow(() -> new ApiException(BlueprintErrorCode.NOT_FOUND_ERROR,"blueprintId : " + blueprintId));

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
@@ -9,6 +9,8 @@ import com.onetool.server.global.exception.BlueprintNullPointException;
 import com.onetool.server.global.new_exception.exception.ApiException;
 import com.onetool.server.global.new_exception.exception.error.BlueprintErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 
@@ -31,26 +33,31 @@ public class BlueprintService {
         return blueprintList;
     }
 
+    @Cacheable(cacheNames = "findAllBluePrintList", key = "'all'")
     public List<Blueprint> findAll(){
         List<Blueprint> blueprintList = blueprintRepository.findAll();
         return blueprintList;
     }
 
+    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public Blueprint findBlueprintById(Long blueprintId) {
         return blueprintRepository.findById(blueprintId)
                 .orElseThrow(() -> new ApiException(BlueprintErrorCode.NOT_FOUND_ERROR,"blueprintId : " + blueprintId));
     }
 
+    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public void saveBlueprint(Blueprint blueprint) {
         validateBlueprintIsNull(blueprint);
         blueprintRepository.save(blueprint);
     }
 
+    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public void updateBlueprint(Blueprint blueprint, BlueprintResponse blueprintResponse) {
         validateBlueprintIsNull(blueprint);
         blueprint.updateBlueprint(blueprintResponse);
     }
 
+    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public void deleteBlueprint(Blueprint blueprint) {
         validateBlueprintIsNull(blueprint);
         blueprintRepository.delete(blueprint);

--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
@@ -33,31 +33,31 @@ public class BlueprintService {
         return blueprintList;
     }
 
-    @Cacheable(cacheNames = "findAllBluePrintList", key = "'all'")
+    public List<Blueprint> findCacheAll(){
+        List<Blueprint> blueprintList = blueprintRepository.findAll();
+        return blueprintList;
+    }
+
     public List<Blueprint> findAll(){
         List<Blueprint> blueprintList = blueprintRepository.findAll();
         return blueprintList;
     }
 
-    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public Blueprint findBlueprintById(Long blueprintId) {
         return blueprintRepository.findById(blueprintId)
                 .orElseThrow(() -> new ApiException(BlueprintErrorCode.NOT_FOUND_ERROR,"blueprintId : " + blueprintId));
     }
 
-    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public void saveBlueprint(Blueprint blueprint) {
         validateBlueprintIsNull(blueprint);
         blueprintRepository.save(blueprint);
     }
 
-    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public void updateBlueprint(Blueprint blueprint, BlueprintResponse blueprintResponse) {
         validateBlueprintIsNull(blueprint);
         blueprint.updateBlueprint(blueprintResponse);
     }
 
-    @CacheEvict(cacheNames = "findAllBluePrintList", allEntries = true)
     public void deleteBlueprint(Blueprint blueprint) {
         validateBlueprintIsNull(blueprint);
         blueprintRepository.delete(blueprint);

--- a/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
@@ -12,12 +12,16 @@ import com.onetool.server.global.annotation.Business;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Business
 @RequiredArgsConstructor
+@Slf4j
 public class OrderBusiness {
 
     private final OrderService orderService;
@@ -35,8 +39,9 @@ public class OrderBusiness {
 
     @Transactional
     public List<MyPageOrderResponse> getMyPageOrderResponseList(@AuthenticationPrincipal PrincipalDetails principal) {
-        Member member = memberService.findOne(principal.getContext().getEmail());
+        Member member = memberService.findOneWithCart(principal.getContext().getId());
         List<Orders> ordersList = orderService.findAllOrdersByUserId(member.getId());
+        List<Blueprint> blueprintList = blueprintService.findAll();
         return MyPageOrderResponse.from(ordersList);
     }
 

--- a/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
@@ -14,6 +14,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
@@ -39,12 +41,11 @@ public class OrderBusiness {
     }
 
     @Transactional
-    @Cacheable(cacheNames = "getMyPageOrderResponseList", key = "#principal.context.id")
-    public List<MyPageOrderResponse> getMyPageOrderResponseList(@AuthenticationPrincipal PrincipalDetails principal) {
+    public List<MyPageOrderResponse> getMyPageOrderResponseList(@AuthenticationPrincipal PrincipalDetails principal, Pageable pageable) {
         Member member = memberService.findOneWithCart(principal.getContext().getId());
-        List<Orders> ordersList = orderService.findAllOrdersByUserId(member.getId());
+        Page<Orders> ordersList = orderService.findAllOrdersByUserId(member.getId(), pageable);
         List<Blueprint> blueprintList = blueprintService.findAll();
-        return MyPageOrderResponse.from(ordersList);
+        return MyPageOrderResponse.from(ordersList.getContent());
     }
 
     @Transactional

--- a/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
@@ -13,6 +13,7 @@ import com.onetool.server.global.auth.login.PrincipalDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
@@ -38,6 +39,7 @@ public class OrderBusiness {
     }
 
     @Transactional
+    @Cacheable(cacheNames = "getMyPageOrderResponseList", key = "#principal.context.id")
     public List<MyPageOrderResponse> getMyPageOrderResponseList(@AuthenticationPrincipal PrincipalDetails principal) {
         Member member = memberService.findOneWithCart(principal.getContext().getId());
         List<Orders> ordersList = orderService.findAllOrdersByUserId(member.getId());

--- a/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
+++ b/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
@@ -8,6 +8,7 @@ import com.onetool.server.global.exception.ApiResponse;
 import com.onetool.server.api.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,8 +32,10 @@ public class OrderController {
     }
 
     @GetMapping
-    public ApiResponse<List<MyPageOrderResponse>> ordersGet(@AuthenticationPrincipal PrincipalDetails principal) {
-        List<MyPageOrderResponse> myPageOrderResponseList = orderBusiness.getMyPageOrderResponseList(principal);
+    public ApiResponse<List<MyPageOrderResponse>> ordersGet(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            Pageable pageable) {
+        List<MyPageOrderResponse> myPageOrderResponseList = orderBusiness.getMyPageOrderResponseList(principal, pageable);
         return ApiResponse.onSuccess(myPageOrderResponseList);
     }
 

--- a/server/src/main/java/com/onetool/server/api/order/dto/response/MyPageOrderResponse.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/response/MyPageOrderResponse.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Builder
 @Slf4j
@@ -37,7 +38,7 @@ public record MyPageOrderResponse(
     }
 
     private static String createOrderName(Orders orders) {
-        log.info("orderItem size: {}", orders.getOrderItems());
+        log.info("order_id : {}",orders.getId());
         StringBuilder sb = new StringBuilder();
         String firstBlueprintName = orders.getOrderItems().get(0).getBlueprint().getBlueprintName();
         int blueprintCount = orders.getOrderItems().size();

--- a/server/src/main/java/com/onetool/server/api/order/dto/response/MyPageOrderResponse.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/response/MyPageOrderResponse.java
@@ -1,5 +1,6 @@
 package com.onetool.server.api.order.dto.response;
 
+import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.order.Orders;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Orders, Long> {
+    @Query("SELECT o FROM Orders o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
+    List<Orders> findByMemberId(@Param("memberId") Long memberId);
 
-    @Query("SELECT o FROM Orders o JOIN FETCH o.member m WHERE m.id = :userId")
-    List<Orders> findByUserId(@Param("userId") Long userId);
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
@@ -1,6 +1,9 @@
 package com.onetool.server.api.order.repository;
 
 import com.onetool.server.api.order.Orders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,5 +13,10 @@ import java.util.List;
 public interface OrderRepository extends JpaRepository<Orders, Long> {
     @Query("SELECT o FROM Orders o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
     List<Orders> findByMemberId(@Param("memberId") Long memberId);
+
+    @EntityGraph(attributePaths = {"payment"})
+    @Query("SELECT o FROM Orders o WHERE o.member.id = :memberId")
+    Page<Orders> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
 
 }

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
@@ -9,6 +9,8 @@ import com.onetool.server.global.new_exception.exception.ApiException;
 import com.onetool.server.global.new_exception.exception.error.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +24,8 @@ public class OrderService {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public List<Orders> findAllOrdersByUserId(Long memberId) {
-        return orderRepository.findByMemberId(memberId);
+    public Page<Orders> findAllOrdersByUserId(Long memberId, Pageable pageable) {
+        return orderRepository.findByMemberId(memberId, pageable);
     }
 
     @Transactional

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
@@ -4,9 +4,7 @@ import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.order.OrderBlueprint;
 import com.onetool.server.api.order.Orders;
 import com.onetool.server.api.order.repository.OrderRepository;
-import com.onetool.server.global.exception.OrderNotFoundException;
 import com.onetool.server.api.member.domain.Member;
-import com.onetool.server.global.exception.OrdersNullPointException;
 import com.onetool.server.global.new_exception.exception.ApiException;
 import com.onetool.server.global.new_exception.exception.error.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +23,7 @@ public class OrderService {
 
     @Transactional
     public List<Orders> findAllOrdersByUserId(Long memberId) {
-        return orderRepository.findByUserId(memberId);
+        return orderRepository.findByMemberId(memberId);
     }
 
     @Transactional
@@ -51,7 +49,7 @@ public class OrderService {
 
     @Transactional(readOnly = true)
     public List<Orders> findAllByUserId(Long userId) {
-        return orderRepository.findByUserId(userId);
+        return orderRepository.findByMemberId(userId);
     }
 
     private void validateOrdersIsNull(Orders orders) {

--- a/server/src/main/java/com/onetool/server/global/entity/BaseEntity.java
+++ b/server/src/main/java/com/onetool/server/global/entity/BaseEntity.java
@@ -1,5 +1,9 @@
 package com.onetool.server.global.entity;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -17,8 +21,12 @@ public abstract class BaseEntity {
 
     @CreationTimestamp
     @Column(updatable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime updatedAt;
 }

--- a/server/src/main/java/com/onetool/server/global/redis/config/RedisCacheConfig.java
+++ b/server/src/main/java/com/onetool/server/global/redis/config/RedisCacheConfig.java
@@ -1,0 +1,50 @@
+package com.onetool.server.global.redis.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager boardCacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); //  LocalDateTime 지원 추가
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                // Redis에 Key를 저장할 때 String으로 직렬화(변환)해서 저장
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()))
+                // Redis에 Value를 저장할 때 Json으로 직렬화(변환)해서 저장
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new Jackson2JsonRedisSerializer<Object>(Object.class)
+                        )
+                )
+                // 데이터의 만료기간(TTL) 설정
+                .entryTtl(Duration.ofMinutes(10L));
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈
# [N+1 문제 완화](#178)
- close #이슈번호


## 🔎 작업 내용
### [결론] 1+ 1 + 1000 + 9 + 1000 = 2011 에서 1 + 1 + 1 +10 =13 개 쿼리로 완화

### [초기]  11.93초가 걸렸다.
![image](https://github.com/user-attachments/assets/d33d0451-8a77-42b1-8702-2d2b9c4c5c1d)
해당 코드는 LAZY로 지연로딩만 설정되어 있고 fetch join 등등 아무것도 안한 상태에서 측정한 결과이다.
그렇다면 쿼리 수가 어떻게 2011이 나왔는지 분석해보자 .

일단 실험을 위해 orders 테이블과 그의 자식 OneToMany로 되어있는 orderBlueprintList 가 있다. 
처음 데이터베이스에 orders에 1000개의 데이터를 삽입하였고 orderBlueprintList 각각 orders하나당 200개씩 데이터를 넣어 
총 20만개의 데이터를 넣었따. 
즉 orders 1L 당 orderBlueprint는 200개씩 있는 셈이다.

## 1+ 1 + 1000 + 9 + 1000 = 2011쿼리 이거부터 분석해 보겠다.
처음 1은 member 쿼리를 날릴 때 사용된 쿼리.
두번째 1은 1000개의 orders를 조회하기 위한 쿼리.
### 세번째 1000은 OneToOne의 고질적인 N+1문제 때문에 발생한 것이다.
즉 order 객체 하나당 payMent 객체가 1:1로 설정되어 있는데 조회 될 때마다 payMent가 실제로 데이터베이스에 있는지 아닌지Hibernate가 쿼리를 직접 날려본다. 그래서 1000개의 orders가 있다면 1000개의 payMent 쿼리를 날리게 된다.

네번째 9는 blueprint 객체 수이다. 
현재 데이터베이스는 9개의 blueprint가 저장되어 있는데 orders의 데이터에 blueprint가 랜덤값으로 저장되게 해놨다. 
그래서 blueprint를 찾을 때마다 쿼리 한개씩 보내게 되는 것이다.

### 마지막 1000개는 orderItems(200) 개를 조회하기 위해 보내는 쿼리이다.
orderItems 가 OneToMany Lazy로 설정되어 있기 때문에 매번 해당 객체에 접근할 때마다 쿼리를 보내게 된다.

---

## [1]. 첫번째 단계 N+1 해결 대명사 fetch join 을 사용해보자 
![fetch_join_orderitems_적용](https://github.com/user-attachments/assets/bbe7f310-eb8e-4edd-9814-e7cf05b74027)

 ### 2분 이상이 걸렸다
 쿼리를 분석해보자 
 1(멤버 쿼리) + 1(order 조회시 모든 orderItems 전체 조회) +  1000(OneToOne payment) + 9(blueprint 9개 각각 조회)  =  1011쿼리가 사용되었다. 

### 쿼리가 줄었는데 오히려 1100% 성능이 안좋아 지게 되었다. 
1. 데이터가 너무 많은 시점에 join 을 걸어버리기 때문에
2. 200000개의 데이터를 한번에 가져오는데 많은 트래픽이 소요 
3. fetch join 사용시 부모 와 자식관계 즉 orders 와 orderBlueprint 사이에서 order가 중복 데이터가 생긴다는 문제이다.

---

## [2]. 두번째 단계 그렇다면 distinct 를 사용하여 중복 데이터를 없애는 방법을 해보자 
### 5분이상 소요 되었다.

![image](https://github.com/user-attachments/assets/d16040c7-249e-4549-adb6-764685b4f346)
원래 의도되로 라면 중복을 제거하고 가져오면 시간이 줄어들 줄 알았는데 5분 이상이 소요가 되었다.

원인을 분석해보자.
1. distinct 사용시 + 컬렉션 관계 일 경우 (@OneToMany) 
여기서 DISTINCT는 DB에서 중복 제거를 시도하지만, orderItems가 컬렉션이므로 JPA 내부에서 추가적인 중복 제거가 발생할 수도 있다고 한다.
DB에서 제거할 수 없는 중복이 발생할 가능성이 있음.
Hibernate가 가져온 데이터를 엔티티 객체로 매핑하면서 중복을 필터링함.

즉 Memory에 가져와서 중복 제거를 수행한다는 셈이다. 결과적으로 시간이 증가한게 이해가 간다.

---

## [3]. 세번째 단계 일단 Payment OneToOne 관계부터 해결해보자. 

```
 @Query("SELECT o FROM Orders o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
    List<Orders> findByMemberId(@Param("memberId") Long memberId);
```

위와 같이 fetch join 을 이용하여 payment를 조회시 쿼리문을 날리게 되면

1000개의 추가적인 쿼리가 날라기자 않고 
order 1번 조회시 같이 조회가 된다. 

저 코드 하나로 1000개의 추가 쿼리가 날라가지 않게 되었다.

## [4]. orderItems에서 fetch join 을 하지 않고 필요할 때마다 쿼리를 날리는 방식으로 변경

현재 orderItems 의 데이터가 너무 많기 때문에 한번에 데이터를 가져오면 성능이 너무 안좋게 나온다.
그래서 필요한 시점일 때 데이터를 가져오는 방식으로 변경하기로 했다. 

다만 필요할때 하나하나 마다 가져오는 방식이 아닌 BatchSize를 설정하여 한번에 50개 ~ 100개정도 가져오는 방법으로 바꿔 보았다.

### [BatchSize 50]
![image](https://github.com/user-attachments/assets/1cea1324-54c6-4f4b-b890-67454b3c6781)

### [BatchSize 100]
![image](https://github.com/user-attachments/assets/221ba47a-1d9d-43bb-a9be-54520bee7577)

사실상 미미하지만 BatchSize 100을 선택했다.

--- 

## [5]. blueprint의 총 갯수 9개 쿼리를 사전에 미리 조회 하는 방식으로 변경 
기존 blueprint가 매번 9번의 쿼리를 날렸는데 사전에 미리 findAll을 하여 영속성 컨텍스트에 관리하게 해결 
9번의 쿼리에서 => 1번의 쿼리로 해결

다만 단점이 유저가 매번 orders 를 조회할 때마다 findAll 을 하여 blueprint를 영속성 컨텍스트에 넣는건 비효율적 이라고 생각한다. 추후 Cache 메모리를 사용하여 리펙터링 아이디어를 생각해 보겠다.
 

### 최종 정리해보자.
1. Member를 조회시 쿼리 한번 발생  == 1 쿼리
2. 1000개의 order 리스트 조회시 쿼리 한번 발생 == 1  쿼리
 3. 기존 OneToOne 관계의 payment는 order 조회시 같이 fetch join 하므로 해결 == 0 쿼리
 4. blueprint 매번 9개의 쿼리에서 1개의 쿼리로 완화  == 1쿼리
 5. orderItems는  배치사이즈를 100으로 설정하여 orders 가 총 1000개 있으므로 10번만 가져오면 된다. == 10 쿼리
 
# 결론 1+ 1+ 0 + 1 + 10 == 13쿼리

### 성능 개선  (Distinct fetch join)최악 5분 53초에서 => (배치사이즈 100)5.96초 
### 성능이 약 98.3% 개선되었습니다. 

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

추가적으로 성능을 최적화할 만한 아이디어가 있을까요?? 

유저의 orders 는 자주 변경되지 않는 사항이라고 생각됩니다.
그래서 캐시 메모리에 적용한 뒤 
트래픽을 얼마나 버틸수 있는지 까지 측정 해보겠습니다.

## 🧲 참고 자료 및 공유 사항
### [N+1 블로그 참고](https://ttl-blog.tistory.com/1135)

