### PR TITLE
feat(Member): idx_name 적용 2.67TPS => 771TPS 성능향상

### DIFF
--- a/server/src/main/java/com/onetool/server/api/member/business/MemberBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/member/business/MemberBusiness.java
@@ -28,8 +28,7 @@ public class MemberBusiness {
 
     @Transactional(readOnly = true)
     public String findEmail(String name, String phoneNum) {
-        Member member = memberService.findOne(name, phoneNum);
-        return member.getEmail();
+        return memberService.findOne(name, phoneNum);
     }
 
     @Transactional(readOnly = true)

--- a/server/src/main/java/com/onetool/server/api/member/domain/Member.java
+++ b/server/src/main/java/com/onetool/server/api/member/domain/Member.java
@@ -26,6 +26,12 @@ import java.util.List;
 import java.util.Optional;
 
 @Entity
+@Table(
+        name = "member",
+        indexes = {
+                @Index(name = "idx_name", columnList = "name")
+        }
+)
 @Getter
 @Setter(value = AccessLevel.PRIVATE)
 @NoArgsConstructor

--- a/server/src/main/java/com/onetool/server/api/member/repository/MemberJpaRepository.java
+++ b/server/src/main/java/com/onetool/server/api/member/repository/MemberJpaRepository.java
@@ -37,8 +37,8 @@ public interface MemberJpaRepository extends MemberRepository, Repository<Member
     @Query("SELECT m FROM Member m LEFT JOIN FETCH m.cart WHERE m.id = :id")
     Optional<Member> findByIdWithCart(@Param("id") Long id);
 
-    @Query("SELECT m FROM Member m WHERE m.name = :name AND m.phoneNum = :phoneNum")
-    Optional<Member> findByNameAndPhoneNum(@Param("name") String name, @Param("phoneNum") String phoneNum);
+    @Query("SELECT m.email FROM Member m WHERE m.name = :name AND m.phoneNum = :phoneNum")
+    Optional<String> findByNameAndPhoneNum(@Param("name") String name, @Param("phoneNum") String phoneNum);
 
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m WHERE m.email = :email")
     boolean existsByEmail(@Param("email") String email);

--- a/server/src/main/java/com/onetool/server/api/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/onetool/server/api/member/repository/MemberRepository.java
@@ -28,7 +28,7 @@ public interface MemberRepository {
 
     Optional<Member> findByIdWithCart(Long id);
 
-    Optional<Member> findByNameAndPhoneNum(String name, String phoneNum);
+    Optional<String> findByNameAndPhoneNum(String name, String phoneNum);
 
     boolean existsByEmail(String email);
 

--- a/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
+++ b/server/src/main/java/com/onetool/server/api/member/service/MemberService.java
@@ -17,7 +17,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public Member findOne(String name, String phoneNumber) {
+    public String findOne(String name, String phoneNumber) {
         return memberRepository.findByNameAndPhoneNum(name, phoneNumber).orElseThrow(() ->
                 new ApiException(MemberErrorCode.NON_EXIST_USER, "이름과 비밀번호가 일치하는 회원이 존재하지 않습니다."));
     }

--- a/server/src/test/java/com/onetool/server/api/member/fake/FakeMemberJpaRepository.java
+++ b/server/src/test/java/com/onetool/server/api/member/fake/FakeMemberJpaRepository.java
@@ -67,10 +67,11 @@ public class FakeMemberJpaRepository implements MemberJpaRepository {
     }
 
     @Override
-    public Optional<Member> findByNameAndPhoneNum(String name, String phoneNum) {
+    public Optional<String> findByNameAndPhoneNum(String name, String phoneNum) {
         return store.values().stream()
                 .filter(m -> m.getName().equals(name) && m.getPhoneNum().equals(phoneNum))
-                .findFirst();
+                .findFirst()
+                .map(Member::getEmail);
     }
 
     @Override

--- a/server/src/test/java/com/onetool/server/api/member/service/MemberServiceTest.java
+++ b/server/src/test/java/com/onetool/server/api/member/service/MemberServiceTest.java
@@ -43,10 +43,10 @@ class MemberServiceTest {
         memberRepository.save(member);
 
         // when
-        Member foundMember = memberService.findOne(member.getName(), member.getPhoneNum());
+        String memberEmail = memberService.findOne(member.getName(), member.getPhoneNum());
 
         // then
-        assertThat(foundMember.getEmail()).isEqualTo(member.getEmail());
+        assertThat(memberEmail).isEqualTo(member.getEmail());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 이슈
### [인덱스 적용 성능 최적화](#178 )
- close #이슈번호


## 🔎 작업 내용
현재 DB Member table 에는 100만개의 데이터가 저장되어 있다. 
```
    @Query("SELECT m FROM Member m WHERE m.name = :name AND m.phoneNum = :phoneNum")
    Optional<Member> findByNameAndPhoneNum(@Param("name") String name, @Param("phoneNum") String phoneNum);
```
해당 쿼리에 관련해서 성능 최적화를 해보았습니다.

위의 JPQL 코드는 데이터베이스에서 아래와 같은 형태의 쿼리로 바뀐다
```
SELECT * FROM member m
WHERE m.name = 'User00021'
  AND m.phone_num = '01036939764'
  AND m.is_deleted = false;
```

### [현재 상황]
Member 에는 email과 pk_id 만 인덱스로 설정되어 있어서 name과 phoneNum는 idx가 설정되어 있지 않습니다.
그래서 만약 Member 레코드가 100만개라고 한다면 name 은  index가 없어서 풀테이블 스캔이 일어나 
100만개의 모든 레코드를 조회해야 되는 최악 상황이 발생합니다.

이러한 이유로 다음아래의 과정을 통해 성능 최적화를 진행했습니다.
### [기존] Postman : 1.4s   DB : 848ms TPS: 2.67tps
![100만 개데이터1 43초](https://github.com/user-attachments/assets/28ea09b3-8248-43c6-a808-4717b8d319ae)
### 848MS
![데이터베이스 풀테이블 스캔 893ch](https://github.com/user-attachments/assets/29e8cd95-bcec-41e1-8b27-9031d3de603c)
### TYPE = ALL(풀테이블 스캔) ROW : 99만개 
![풀테이블스캔 및 99만개 조회](https://github.com/user-attachments/assets/86b87160-168a-4e00-bae9-701037bf0d08)
### [TPS]
![기존  풀테이 블스 캔  2 67tps](https://github.com/user-attachments/assets/4613b75b-807b-4eb7-858c-6b1b8b28114d)




## [인덱스 적용]

### 1. name만 index 적용해보기 90ms

![name만 idx 만 90](https://github.com/user-attachments/assets/66401271-f948-4313-bda3-5a1629e532d7)
![name만 idx ref](https://github.com/user-attachments/assets/a1cc67a3-2502-445f-96d8-312e9cbd2ae5)

### 2.phone_num 만 index 적용해보기 75,ms
![phone_num type=ref](https://github.com/user-attachments/assets/b4b34e39-f541-4fda-ae42-19aae49f712a)
![phone_num_idx 만 설정 75ms](https://github.com/user-attachments/assets/38669f07-a84b-49d6-83f8-99fb69cb5c89)

### 3. name 과 phone_num 복합인덱스 설정해보기 93ms

![name,phone 복합인덱 스type =ref](https://github.com/user-attachments/assets/668f9310-6cf4-4aec-b12f-17f5d8f4c0fa)

![name,phone, 복합인덱스 설정 90ms](https://github.com/user-attachments/assets/0f3f455e-525d-4b2e-9836-dbacb86d2357)

### 4. name과 phone_num과 is_deleted 복합인덱스 설정해보기 81ms
![3개 복합인덱스 type](https://github.com/user-attachments/assets/1216bdef-e761-41e1-af79-1abfc9e8a64c)

![3개의 복합인덱스 81ms](https://github.com/user-attachments/assets/ad0d30d6-13c4-4325-813e-fdc94dae066e)

### 5. name과 phone_num과 is_deleted와 email 즉 커버링 인덱스사용 유도해보기 39ms
![커버링인덱스](https://github.com/user-attachments/assets/b9da0345-c712-4ca7-8bbf-813a79fcf430)
![커버링인덱스 데베 코드](https://github.com/user-attachments/assets/0dc3d360-a10f-4a08-9ed1-2d1d0634928e)


### [최종 결론] name만 index사용하기로 결정 771TPS
![인덱스스캔 771tps](https://github.com/user-attachments/assets/c869b195-ca10-4810-a6d3-1e5fe0973123)

# 771 TPS / 2.16 TPS = 357.87배 성능 향상

###  결론 해설: 인덱스 설계와 커버링 인덱스의 성능

####  기본 인덱스 동작 방식
- `name` 혹은 `phone_num` 중 하나만 인덱스를 설정한 경우:
  - 옵티마이저는 해당 **인덱스 트리**를 통해 **리프 노드의 `pk_id` 주소**를 탐색한다.
  - 이후 `pk`가 만든 **클러스터링 인덱스**를 통해 최종적으로 원하는 **레코드**를 가져온다.
  - 이 과정에서 **관련 페이지들은 디스크에서 로드**된다.
  -  따라서 **무식한 풀 테이블 스캔**보다는 인덱스를 통해 **디스크 I/O를 줄여 성능이 최적화**된다.

####  그런데 왜 복합 인덱스 (`name`, `phone_num`, `is_deleted`)를 설정해도 성능 변화가 크지 않을까?
- 이유는 **기본 동작과 동일**하다.
  - 인덱스 트리를 따라가도 결국에는 **리프 노드에 있는 `pk` 주소를 통해 클러스터링 인덱스를 조회**해야 하기 때문이다.
  - 즉, **디스크에 최소 1번 이상은 접근**해야 하는 구조는 변하지 않는다.

####  그래서 등장한 아이디어: **커버링 인덱스**
- **클러스터링 인덱스를 조회하지 않고**, 인덱스 트리만으로 데이터를 조회할 수 있다면?
-  디스크 접근 없이 성능을 최적화할 수 있지 않을까?

####  실제 실행 결과
- **커버링 인덱스 적용 후**:  
  - 성능이 **약 39ms**, 기존 대비 **2~3배 향상**되었음.

####  하지만 문제점도 존재
- 인덱스를 구성하는 컬럼 수가 **4개**나 된다.
- 인덱스 컬럼 수가 많을수록:
  - `INSERT`, `UPDATE` 등 **쓰기 성능 저하** 발생
  - 하나의 인덱스만 설정했을 때처럼 **극적인 성능 향상은 어려움**

####  최종 선택
- **범용성과 성능의 균형**을 고려하여,
  - `name` 하나만 인덱스를 설정하는 것이 가장 현실적이라 판단함.




## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
혹시 문제 있거나 궁금하신 내용 있으시면 리뷰 부탁드립니다. 
감사합니다 : )

## 🧲 참고 자료 및 공유 사항


