### PR TITLE
feat(Orders): JpaRepository 의존성 약화 => Repository 상속받는 형태로

### DIFF
--- a/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
+++ b/server/src/main/java/com/onetool/server/api/blueprint/service/BlueprintService.java
@@ -33,11 +33,6 @@ public class BlueprintService {
         return blueprintList;
     }
 
-    public List<Blueprint> findCacheAll(){
-        List<Blueprint> blueprintList = blueprintRepository.findAll();
-        return blueprintList;
-    }
-
     public List<Blueprint> findAll(){
         List<Blueprint> blueprintList = blueprintRepository.findAll();
         return blueprintList;

--- a/server/src/main/java/com/onetool/server/api/member/business/MemberLoginBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/member/business/MemberLoginBusiness.java
@@ -36,7 +36,9 @@ public class MemberLoginBusiness {
             log.error("비밀번호 불일치: {}", encoder.encode(member.getPassword()));
             throw new ApiException(LoginErrorCode.INVALID_PASSWORD);
         }
-
+        log.info("fuck");
+        System.out.println(member.getName());
+        System.out.println(member.getRole());
         MemberAuthContext context = MemberAuthContext.from(member);
         return jwtUtil.createTokens(context);
     }

--- a/server/src/main/java/com/onetool/server/api/member/business/MemberLoginBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/member/business/MemberLoginBusiness.java
@@ -36,9 +36,6 @@ public class MemberLoginBusiness {
             log.error("비밀번호 불일치: {}", encoder.encode(member.getPassword()));
             throw new ApiException(LoginErrorCode.INVALID_PASSWORD);
         }
-        log.info("fuck");
-        System.out.println(member.getName());
-        System.out.println(member.getRole());
         MemberAuthContext context = MemberAuthContext.from(member);
         return jwtUtil.createTokens(context);
     }

--- a/server/src/main/java/com/onetool/server/api/member/domain/Member.java
+++ b/server/src/main/java/com/onetool/server/api/member/domain/Member.java
@@ -4,10 +4,9 @@ import com.onetool.server.api.cart.Cart;
 import com.onetool.server.api.member.dto.command.MemberUpdateCommand;
 import com.onetool.server.api.member.enums.SocialType;
 import com.onetool.server.api.member.enums.UserRole;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.api.order.OrderBlueprint;
 import com.onetool.server.global.entity.BaseEntity;
-import com.onetool.server.api.member.dto.request.MemberUpdateRequest;
-import com.onetool.server.api.order.Orders;
 import com.onetool.server.api.qna.QnaBoard;
 import com.onetool.server.api.qna.QnaReply;
 import jakarta.persistence.*;
@@ -81,7 +80,7 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member")
     @OrderBy("createdAt DESC")
-    private List<Orders> orders = new ArrayList<>();
+    private List<Order> orders = new ArrayList<>();
 
     @Column(nullable = false)
     private boolean isDeleted = false;
@@ -110,6 +109,6 @@ public class Member extends BaseEntity {
     }
 
     public List<OrderBlueprint> getOrderBlueprints() {
-        return Orders.getOrderItems(getOrders());
+        return Order.getOrderItems(getOrders());
     }
 }

--- a/server/src/main/java/com/onetool/server/api/member/dto/response/MemberInfoResponse.java
+++ b/server/src/main/java/com/onetool/server/api/member/dto/response/MemberInfoResponse.java
@@ -1,7 +1,7 @@
 package com.onetool.server.api.member.dto.response;
 
 import com.onetool.server.api.member.domain.Member;
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.api.order.dto.response.OrderResponse;
 import jakarta.validation.constraints.Past;
 import lombok.Builder;
@@ -38,7 +38,7 @@ public record MemberInfoResponse(
                 .build();
     }
 
-    private static List<OrderResponse.OrderCompleteResponseDto> convertOrdersToResponse(List<Orders> orders) {
+    private static List<OrderResponse.OrderCompleteResponseDto> convertOrdersToResponse(List<Order> orders) {
         return Optional.ofNullable(orders)
                 .orElse(List.of())
                 .stream()

--- a/server/src/main/java/com/onetool/server/api/order/Order.java
+++ b/server/src/main/java/com/onetool/server/api/order/Order.java
@@ -5,9 +5,9 @@ import com.onetool.server.api.payments.domain.Payment;
 import com.onetool.server.api.payments.domain.PaymentStatus;
 import com.onetool.server.global.entity.BaseEntity;
 import com.onetool.server.api.member.domain.Member;
-import com.onetool.server.api.payments.TossPayments;
 import jakarta.persistence.*;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Table;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.*;
@@ -24,7 +24,8 @@ import java.util.List;
 @SQLDelete(sql = "UPDATE Orders SET is_deleted = true WHERE id = ?")
 @SQLRestriction("is_deleted = false")
 @Slf4j
-public class Orders extends BaseEntity {
+@Table(name ="orders")
+public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -43,16 +44,16 @@ public class Orders extends BaseEntity {
     private List<OrderBlueprint> orderItems = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_member_id")
+    @JoinColumn(name="member_id")
     private Member member;
 
-    @OneToOne(mappedBy = "orders", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
     private Payment payment;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
-    public Orders(List<Blueprint> blueprints) {
+    public Order(List<Blueprint> blueprints) {
         this.totalCount = blueprints.size();
         this.totalPrice = calcTotalPrice(blueprints);
     }
@@ -83,7 +84,7 @@ public class Orders extends BaseEntity {
         }
     }
 
-    public static List<OrderBlueprint> getOrderItems(List<Orders> orders) {
+    public static List<OrderBlueprint> getOrderItems(List<Order> orders) {
         return orders.stream()
                 .flatMap(order -> order.getOrderItems().stream())
                 .toList();

--- a/server/src/main/java/com/onetool/server/api/order/OrderBlueprint.java
+++ b/server/src/main/java/com/onetool/server/api/order/OrderBlueprint.java
@@ -25,8 +25,8 @@ public class OrderBlueprint extends BaseEntity {
     private Blueprint blueprint;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "orders_id")
-    private Orders order;
+    @JoinColumn(name = "order_id")
+    private Order order;
 
     private String downloadUrl;
 
@@ -38,7 +38,7 @@ public class OrderBlueprint extends BaseEntity {
     }
 
     //연관관계 맺기~~~~~~
-    public void assignOrder(Orders order) {
+    public void assignOrder(Order order) {
         if (this.order != order) {
             this.order = order;
             order.getOrderItems().add(this);

--- a/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
+import java.util.Set;
 
 @Business
 @RequiredArgsConstructor
@@ -29,17 +30,17 @@ public class OrderBusiness {
     private final BlueprintService blueprintService;
 
     @Transactional
-    public Long createOrder(PrincipalDetails principalDetails, OrderRequest orderRequest) {
-        Member member = memberService.findOne(principalDetails.getContext().getEmail());
-        List<Blueprint> blueprintList = blueprintService.findAllBlueprintByIds(orderRequest.blueprintIds());
+    public Long createOrder(String userEmail, Set<Long> blueprintIds) {
+        Member member = memberService.findOne(userEmail);
+        List<Blueprint> blueprintList = blueprintService.findAllBlueprintByIds(blueprintIds);
         Order order = new Order(blueprintList);
 
         return orderService.saveOrder(order, member, blueprintList);
     }
 
     @Transactional
-    public List<MyPageOrderResponse> getMyPageOrderResponseList(@AuthenticationPrincipal PrincipalDetails principal, Pageable pageable) {
-        Member member = memberService.findOneWithCart(principal.getContext().getId());
+    public List<MyPageOrderResponse> getMyPageOrderResponseList(Long userId, Pageable pageable) {
+        Member member = memberService.findOneWithCart(userId);
         Page<Order> ordersList = orderService.findAllOrderByUserId(member.getId(), pageable);
         List<Blueprint> blueprintList = blueprintService.findAll();
         return MyPageOrderResponse.from(ordersList.getContent());

--- a/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
@@ -5,17 +5,14 @@ import com.onetool.server.api.blueprint.service.BlueprintService;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.service.MemberService;
 import com.onetool.server.api.order.Order;
-import com.onetool.server.api.order.dto.request.OrderRequest;
 import com.onetool.server.api.order.dto.response.MyPageOrderResponse;
 import com.onetool.server.api.order.service.OrderService;
 import com.onetool.server.global.annotation.Business;
-import com.onetool.server.global.auth.login.PrincipalDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
 import java.util.Set;
@@ -41,14 +38,14 @@ public class OrderBusiness {
     @Transactional
     public List<MyPageOrderResponse> getMyPageOrderResponseList(Long userId, Pageable pageable) {
         Member member = memberService.findOneWithCart(userId);
-        Page<Order> ordersList = orderService.findAllOrderByUserId(member.getId(), pageable);
+        Page<Order> ordersList = orderService.findAll(member.getId(), pageable);
         List<Blueprint> blueprintList = blueprintService.findAll();
         return MyPageOrderResponse.from(ordersList.getContent());
     }
 
     @Transactional
     public void removeOrder(Long orderId) {
-        Order order = orderService.findOrderById(orderId);
+        Order order = orderService.findOne(orderId);
         orderService.deleteOrder(order);
     }
 }

--- a/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/order/business/OrderBusiness.java
@@ -4,7 +4,7 @@ import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.blueprint.service.BlueprintService;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.member.service.MemberService;
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.api.order.dto.request.OrderRequest;
 import com.onetool.server.api.order.dto.response.MyPageOrderResponse;
 import com.onetool.server.api.order.service.OrderService;
@@ -13,14 +13,11 @@ import com.onetool.server.global.auth.login.PrincipalDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Business
 @RequiredArgsConstructor
@@ -35,22 +32,22 @@ public class OrderBusiness {
     public Long createOrder(PrincipalDetails principalDetails, OrderRequest orderRequest) {
         Member member = memberService.findOne(principalDetails.getContext().getEmail());
         List<Blueprint> blueprintList = blueprintService.findAllBlueprintByIds(orderRequest.blueprintIds());
-        Orders orders = new Orders(blueprintList);
+        Order order = new Order(blueprintList);
 
-        return orderService.saveOrder(orders, member, blueprintList);
+        return orderService.saveOrder(order, member, blueprintList);
     }
 
     @Transactional
     public List<MyPageOrderResponse> getMyPageOrderResponseList(@AuthenticationPrincipal PrincipalDetails principal, Pageable pageable) {
         Member member = memberService.findOneWithCart(principal.getContext().getId());
-        Page<Orders> ordersList = orderService.findAllOrdersByUserId(member.getId(), pageable);
+        Page<Order> ordersList = orderService.findAllOrderByUserId(member.getId(), pageable);
         List<Blueprint> blueprintList = blueprintService.findAll();
         return MyPageOrderResponse.from(ordersList.getContent());
     }
 
     @Transactional
-    public void removeOrders(Long orderId) {
-        Orders orders = orderService.findOrdersById(orderId);
-        orderService.deleteOrder(orders);
+    public void removeOrder(Long orderId) {
+        Order order = orderService.findOrderById(orderId);
+        orderService.deleteOrder(order);
     }
 }

--- a/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
+++ b/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
@@ -5,7 +5,6 @@ import com.onetool.server.api.order.dto.request.OrderRequest;
 import com.onetool.server.api.order.dto.response.MyPageOrderResponse;
 import com.onetool.server.global.auth.login.PrincipalDetails;
 import com.onetool.server.global.exception.ApiResponse;
-import com.onetool.server.api.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +22,7 @@ public class OrderController {
     private final OrderBusiness orderBusiness;
 
     @PostMapping
-    public ApiResponse<Long> ordersPost(
+    public ApiResponse<Long> orderPost(
             @AuthenticationPrincipal PrincipalDetails principal,
             @Valid @RequestBody OrderRequest request
     ) {
@@ -32,7 +31,7 @@ public class OrderController {
     }
 
     @GetMapping
-    public ApiResponse<List<MyPageOrderResponse>> ordersGet(
+    public ApiResponse<List<MyPageOrderResponse>> orderGet(
             @AuthenticationPrincipal PrincipalDetails principal,
             Pageable pageable) {
         List<MyPageOrderResponse> myPageOrderResponseList = orderBusiness.getMyPageOrderResponseList(principal, pageable);
@@ -40,10 +39,10 @@ public class OrderController {
     }
 
     @DeleteMapping
-    public ApiResponse<Long> ordersDelete(
+    public ApiResponse<Long> orderDelete(
             @RequestBody Long orderId
     ) {
-        orderBusiness.removeOrders(orderId);
+        orderBusiness.removeOrder(orderId);
         return ApiResponse.onSuccess(orderId);
     }
 }

--- a/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
+++ b/server/src/main/java/com/onetool/server/api/order/controller/OrderController.java
@@ -26,7 +26,7 @@ public class OrderController {
             @AuthenticationPrincipal PrincipalDetails principal,
             @Valid @RequestBody OrderRequest request
     ) {
-        Long orderId = orderBusiness.createOrder(principal, request);
+        Long orderId = orderBusiness.createOrder(principal.getContext().getEmail(), request.blueprintIds());
         return ApiResponse.onSuccess(orderId);
     }
 
@@ -34,7 +34,7 @@ public class OrderController {
     public ApiResponse<List<MyPageOrderResponse>> orderGet(
             @AuthenticationPrincipal PrincipalDetails principal,
             Pageable pageable) {
-        List<MyPageOrderResponse> myPageOrderResponseList = orderBusiness.getMyPageOrderResponseList(principal, pageable);
+        List<MyPageOrderResponse> myPageOrderResponseList = orderBusiness.getMyPageOrderResponseList(principal.getContext().getId(), pageable);
         return ApiResponse.onSuccess(myPageOrderResponseList);
     }
 

--- a/server/src/main/java/com/onetool/server/api/order/dto/response/MyPageOrderResponse.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/response/MyPageOrderResponse.java
@@ -1,13 +1,11 @@
 package com.onetool.server.api.order.dto.response;
 
-import com.onetool.server.api.blueprint.Blueprint;
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Builder
 @Slf4j
@@ -18,13 +16,13 @@ public record MyPageOrderResponse(
         String status,
         List<String> downloadUrl
 ){
-    public static List<MyPageOrderResponse> from(List<Orders> ordersList){
+    public static List<MyPageOrderResponse> from(List<Order> orderList){
         List<MyPageOrderResponse> dtos = new ArrayList<>();
-        if(isOrderEmpty(ordersList)) {
+        if(isOrderEmpty(orderList)) {
             return dtos;
         }
 
-        ordersList.forEach(orders -> {
+        orderList.forEach(orders -> {
             dtos.add(
                     MyPageOrderResponse.builder()
                             .orderId(orders.getId())
@@ -38,11 +36,11 @@ public record MyPageOrderResponse(
         return dtos;
     }
 
-    private static String createOrderName(Orders orders) {
-        log.info("order_id : {}",orders.getId());
+    private static String createOrderName(Order order) {
+        log.info("order_id : {}", order.getId());
         StringBuilder sb = new StringBuilder();
-        String firstBlueprintName = orders.getOrderItems().get(0).getBlueprint().getBlueprintName();
-        int blueprintCount = orders.getOrderItems().size();
+        String firstBlueprintName = order.getOrderItems().get(0).getBlueprint().getBlueprintName();
+        int blueprintCount = order.getOrderItems().size();
         sb.append(firstBlueprintName);
 
         if (blueprintCount > 1) {
@@ -54,7 +52,7 @@ public record MyPageOrderResponse(
         return sb.toString();
     }
 
-    private static boolean isOrderEmpty(List<Orders> ordersList) {
-        return ordersList.isEmpty();
+    private static boolean isOrderEmpty(List<Order> orderList) {
+        return orderList.isEmpty();
     }
 }

--- a/server/src/main/java/com/onetool/server/api/order/dto/response/OrderCompleteResponse.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/response/OrderCompleteResponse.java
@@ -1,7 +1,7 @@
 package com.onetool.server.api.order.dto.response;
 
 import com.onetool.server.api.blueprint.dto.response.BlueprintResponse;
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import lombok.Builder;
 
 import java.util.List;
@@ -11,10 +11,10 @@ public record OrderCompleteResponse(
         Long totalPrice,
         List<BlueprintResponse> blueprints
 ){
-    public static OrderCompleteResponse response(Orders orders){
+    public static OrderCompleteResponse response(Order order){
         return OrderCompleteResponse.builder()
-                .totalPrice(orders.getTotalPrice())
-                .blueprints(orders.getOrderItems()
+                .totalPrice(order.getTotalPrice())
+                .blueprints(order.getOrderItems()
                         .stream()
                         .map(orderBlueprint ->
                                 BlueprintResponse.items(orderBlueprint.getBlueprint()))

--- a/server/src/main/java/com/onetool/server/api/order/dto/response/OrderResponse.java
+++ b/server/src/main/java/com/onetool/server/api/order/dto/response/OrderResponse.java
@@ -1,7 +1,7 @@
 package com.onetool.server.api.order.dto.response;
 
 import com.onetool.server.api.blueprint.dto.response.BlueprintResponse;
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,13 +19,13 @@ public class OrderResponse {
             String status,
             List<String> downloadUrl
     ) {
-        public static List<MyPageOrderResponseDto> from(List<Orders> ordersList) {
+        public static List<MyPageOrderResponseDto> from(List<Order> orderList) {
             List<MyPageOrderResponseDto> dtos = new ArrayList<>();
-            if (isOrderEmpty(ordersList)) {
+            if (isOrderEmpty(orderList)) {
                 return dtos;
             }
 
-            ordersList.forEach(orders -> {
+            orderList.forEach(orders -> {
                 dtos.add(
                         MyPageOrderResponseDto.builder()
                                 .orderId(orders.getId())
@@ -39,11 +39,11 @@ public class OrderResponse {
             return dtos;
         }
 
-        private static String createOrderName(Orders orders) {
-            log.info("orderItem size: {}", orders.getOrderItems());
+        private static String createOrderName(Order order) {
+            log.info("orderItem size: {}", order.getOrderItems());
             StringBuilder sb = new StringBuilder();
-            String firstBlueprintName = orders.getOrderItems().get(0).getBlueprint().getBlueprintName();
-            int blueprintCount = orders.getOrderItems().size();
+            String firstBlueprintName = order.getOrderItems().get(0).getBlueprint().getBlueprintName();
+            int blueprintCount = order.getOrderItems().size();
             sb.append(firstBlueprintName);
 
             if (blueprintCount > 1) {
@@ -55,8 +55,8 @@ public class OrderResponse {
             return sb.toString();
         }
 
-        private static boolean isOrderEmpty(List<Orders> ordersList) {
-            return ordersList.isEmpty();
+        private static boolean isOrderEmpty(List<Order> orderList) {
+            return orderList.isEmpty();
         }
 
     }
@@ -66,10 +66,10 @@ public class OrderResponse {
             Long totalPrice,
             List<BlueprintResponse> blueprints
     ) {
-        public static OrderCompleteResponseDto response(Orders orders) {
+        public static OrderCompleteResponseDto response(Order order) {
             return OrderCompleteResponseDto.builder()
-                    .totalPrice(orders.getTotalPrice())
-                    .blueprints(orders.getOrderItems()
+                    .totalPrice(order.getTotalPrice())
+                    .blueprints(order.getOrderItems()
                             .stream()
                             .map(orderBlueprint ->
                                     BlueprintResponse.items(orderBlueprint.getBlueprint()))

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderBlueprintJpaRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderBlueprintJpaRepository.java
@@ -4,5 +4,5 @@ import com.onetool.server.api.order.OrderBlueprint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.Repository;
 
-public interface OrderBlueprintJpaRepository extends OrderBlueprintRepository, Repository<OrderBlueprint, Long> {
+public interface OrderBlueprintJpaRepository extends OrderBlueprintRepository, JpaRepository<OrderBlueprint, Long> {
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderBlueprintJpaRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderBlueprintJpaRepository.java
@@ -1,0 +1,8 @@
+package com.onetool.server.api.order.repository;
+
+import com.onetool.server.api.order.OrderBlueprint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
+
+public interface OrderBlueprintJpaRepository extends OrderBlueprintRepository, Repository<OrderBlueprint, Long> {
+}

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderBlueprintRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderBlueprintRepository.java
@@ -1,7 +1,5 @@
 package com.onetool.server.api.order.repository;
 
-import com.onetool.server.api.order.OrderBlueprint;
-import org.springframework.data.jpa.repository.JpaRepository;
+public interface OrderBlueprintRepository {
 
-public interface OrderBlueprintRepository extends JpaRepository<OrderBlueprint, Long> {
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -14,8 +15,7 @@ import java.util.Optional;
 
 @org.springframework.stereotype.Repository
 @Primary
-public interface OrderJpaRepository extends OrderRepository, Repository<Order, Long> {
-
+public interface OrderJpaRepository extends OrderRepository, JpaRepository<Order, Long> {
 
     Optional<Order> findById(Long id);
 
@@ -29,6 +29,5 @@ public interface OrderJpaRepository extends OrderRepository, Repository<Order, L
     @EntityGraph(attributePaths = {"payment"})
     @Query("SELECT o FROM Order o WHERE o.member.id = :memberId")
     Page<Order> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
-
 
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
@@ -24,10 +24,10 @@ public interface OrderJpaRepository extends OrderRepository, JpaRepository<Order
     void deleteById(Long id);
 
     @Query("SELECT o FROM Order o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
-    List<Order> findByMemberId(@Param("memberId") Long memberId);
+    List<Order> findAllByMemberId(@Param("memberId") Long memberId);
 
     @EntityGraph(attributePaths = {"payment"})
     @Query("SELECT o FROM Order o WHERE o.member.id = :memberId")
-    Page<Order> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+    Page<Order> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
@@ -1,0 +1,35 @@
+package com.onetool.server.api.order.repository;
+
+import com.onetool.server.api.order.Orders;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+@org.springframework.stereotype.Repository
+@Primary
+public interface OrderJpaRepository extends OrderRepository, Repository<Orders, Long> {
+
+
+    Optional<Orders> findById(Long id);
+
+    Orders save(Orders orders);
+
+    void deleteById(Long id);
+
+    @Query("SELECT o FROM Orders o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
+    List<Orders> findByMemberId(@Param("memberId") Long memberId);
+
+    @EntityGraph(attributePaths = {"payment"})
+    @Query("SELECT o FROM Orders o WHERE o.member.id = :memberId")
+    Page<Orders> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+
+}

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderJpaRepository.java
@@ -1,11 +1,10 @@
 package com.onetool.server.api.order.repository;
 
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -15,21 +14,21 @@ import java.util.Optional;
 
 @org.springframework.stereotype.Repository
 @Primary
-public interface OrderJpaRepository extends OrderRepository, Repository<Orders, Long> {
+public interface OrderJpaRepository extends OrderRepository, Repository<Order, Long> {
 
 
-    Optional<Orders> findById(Long id);
+    Optional<Order> findById(Long id);
 
-    Orders save(Orders orders);
+    Order save(Order order);
 
     void deleteById(Long id);
 
-    @Query("SELECT o FROM Orders o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
-    List<Orders> findByMemberId(@Param("memberId") Long memberId);
+    @Query("SELECT o FROM Order o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
+    List<Order> findByMemberId(@Param("memberId") Long memberId);
 
     @EntityGraph(attributePaths = {"payment"})
-    @Query("SELECT o FROM Orders o WHERE o.member.id = :memberId")
-    Page<Orders> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+    @Query("SELECT o FROM Order o WHERE o.member.id = :memberId")
+    Page<Order> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
 
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
@@ -1,9 +1,8 @@
 package com.onetool.server.api.order.repository;
 
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,10 +10,10 @@ import java.util.Optional;
 
 public interface OrderRepository {
 
-    Optional<Orders> findById(Long id);
-    Orders save(Orders orders);
+    Optional<Order> findById(Long id);
+    Order save(Order order);
     void deleteById(Long id);
 
-    List<Orders> findByMemberId( Long memberId);
-    Page<Orders> findByMemberId(Long memberId, Pageable pageable);
+    List<Order> findByMemberId(Long memberId);
+    Page<Order> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
@@ -3,20 +3,18 @@ package com.onetool.server.api.order.repository;
 import com.onetool.server.api.order.Orders;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-
-public interface OrderRepository extends JpaRepository<Orders, Long> {
-    @Query("SELECT o FROM Orders o LEFT JOIN FETCH o.payment WHERE o.member.id = :memberId")
-    List<Orders> findByMemberId(@Param("memberId") Long memberId);
-
-    @EntityGraph(attributePaths = {"payment"})
-    @Query("SELECT o FROM Orders o WHERE o.member.id = :memberId")
-    Page<Orders> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+import java.util.Optional;
 
 
+public interface OrderRepository {
+
+    Optional<Orders> findById(Long id);
+    Orders save(Orders orders);
+    void deleteById(Long id);
+
+    List<Orders> findByMemberId( Long memberId);
+    Page<Orders> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
@@ -13,7 +13,6 @@ public interface OrderRepository {
     Optional<Order> findById(Long id);
     Order save(Order order);
     void deleteById(Long id);
-
     List<Order> findByMemberId(Long memberId);
     Page<Order> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
+++ b/server/src/main/java/com/onetool/server/api/order/repository/OrderRepository.java
@@ -13,6 +13,6 @@ public interface OrderRepository {
     Optional<Order> findById(Long id);
     Order save(Order order);
     void deleteById(Long id);
-    List<Order> findByMemberId(Long memberId);
-    Page<Order> findByMemberId(Long memberId, Pageable pageable);
+    List<Order> findAllByMemberId(Long memberId);
+    Page<Order> findAllByMemberId(Long memberId, Pageable pageable);
 }

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
@@ -24,12 +24,12 @@ public class OrderService {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public Page<Order> findAllOrderByUserId(Long memberId, Pageable pageable) {
-        return orderRepository.findByMemberId(memberId, pageable);
+    public Page<Order> findAll(Long memberId, Pageable pageable) {
+        return orderRepository.findAllByMemberId(memberId, pageable);
     }
 
     @Transactional
-    public Order findOrderById(Long orderId) {
+    public Order findOne(Long orderId) {
         return orderRepository.findById(orderId)
                 .orElseThrow(() -> new ApiException(OrderErrorCode.NOT_FOUND_ERROR,"orderId : "+orderId));
     }
@@ -50,8 +50,8 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public List<Order> findAllByUserId(Long userId) {
-        return orderRepository.findByMemberId(userId);
+    public List<Order> findAll(Long userId) {
+        return orderRepository.findAllByMemberId(userId);
     }
 
     private void validateOrderIsNull(Order order) {

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
@@ -2,8 +2,7 @@ package com.onetool.server.api.order.service;
 
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.order.OrderBlueprint;
-import com.onetool.server.api.order.Orders;
-import com.onetool.server.api.order.repository.OrderJpaRepository;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.api.member.domain.Member;
 import com.onetool.server.api.order.repository.OrderRepository;
 import com.onetool.server.global.new_exception.exception.ApiException;
@@ -25,47 +24,47 @@ public class OrderService {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public Page<Orders> findAllOrdersByUserId(Long memberId, Pageable pageable) {
+    public Page<Order> findAllOrderByUserId(Long memberId, Pageable pageable) {
         return orderRepository.findByMemberId(memberId, pageable);
     }
 
     @Transactional
-    public Orders findOrdersById(Long orderId) {
+    public Order findOrderById(Long orderId) {
         return orderRepository.findById(orderId)
                 .orElseThrow(() -> new ApiException(OrderErrorCode.NOT_FOUND_ERROR,"orderId : "+orderId));
     }
 
     @Transactional
-    public Long saveOrder(Orders orders, Member member, List<Blueprint> blueprintList) {
-        validateOrdersIsNull(orders);
-        assignAllConnectOrders(orders, member, blueprintList);
-        Orders saveOrders = orderRepository.save(orders);
+    public Long saveOrder(Order order, Member member, List<Blueprint> blueprintList) {
+        validateOrderIsNull(order);
+        assignAllConnectOrders(order, member, blueprintList);
+        Order saveOrder = orderRepository.save(order);
 
-        return saveOrders.getId();
+        return saveOrder.getId();
     }
 
     @Transactional
-    public void deleteOrder(Orders orders) {
-        validateOrdersIsNull(orders);
-        orderRepository.deleteById(orders.getId());
+    public void deleteOrder(Order order) {
+        validateOrderIsNull(order);
+        orderRepository.deleteById(order.getId());
     }
 
     @Transactional(readOnly = true)
-    public List<Orders> findAllByUserId(Long userId) {
+    public List<Order> findAllByUserId(Long userId) {
         return orderRepository.findByMemberId(userId);
     }
 
-    private void validateOrdersIsNull(Orders orders) {
-        if (orders == null) {
+    private void validateOrderIsNull(Order order) {
+        if (order == null) {
             throw new ApiException(OrderErrorCode.NULL_POINT_ERROR,"Orders 객체가 NULL입니다.");
         }
     }
 
-    private void assignAllConnectOrders(Orders orders, Member member, List<Blueprint> blueprintList) {
-        orders.assignMember(member);
+    private void assignAllConnectOrders(Order order, Member member, List<Blueprint> blueprintList) {
+        order.assignMember(member);
         blueprintList.forEach(blueprint -> {
             OrderBlueprint orderBlueprint = new OrderBlueprint(blueprint.getDownloadLink());
-            orderBlueprint.assignOrder(orders);
+            orderBlueprint.assignOrder(order);
             orderBlueprint.assignBlueprint(blueprint);
         });
     }

--- a/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
+++ b/server/src/main/java/com/onetool/server/api/order/service/OrderService.java
@@ -3,8 +3,9 @@ package com.onetool.server.api.order.service;
 import com.onetool.server.api.blueprint.Blueprint;
 import com.onetool.server.api.order.OrderBlueprint;
 import com.onetool.server.api.order.Orders;
-import com.onetool.server.api.order.repository.OrderRepository;
+import com.onetool.server.api.order.repository.OrderJpaRepository;
 import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.order.repository.OrderRepository;
 import com.onetool.server.global.new_exception.exception.ApiException;
 import com.onetool.server.global.new_exception.exception.error.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -38,15 +39,15 @@ public class OrderService {
     public Long saveOrder(Orders orders, Member member, List<Blueprint> blueprintList) {
         validateOrdersIsNull(orders);
         assignAllConnectOrders(orders, member, blueprintList);
-        orderRepository.save(orders);
+        Orders saveOrders = orderRepository.save(orders);
 
-        return orders.getId();
+        return saveOrders.getId();
     }
 
     @Transactional
     public void deleteOrder(Orders orders) {
         validateOrdersIsNull(orders);
-        orderRepository.delete(orders);
+        orderRepository.deleteById(orders.getId());
     }
 
     @Transactional(readOnly = true)

--- a/server/src/main/java/com/onetool/server/api/payments/TossPayments.java
+++ b/server/src/main/java/com/onetool/server/api/payments/TossPayments.java
@@ -1,7 +1,7 @@
 package com.onetool.server.api.payments;
 
+import com.onetool.server.api.order.Order;
 import com.onetool.server.global.entity.BaseEntity;
-import com.onetool.server.api.order.Orders;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,5 +24,5 @@ public class TossPayments extends BaseEntity {
     private String paymentLastTransactionKey;
 
     @OneToOne
-    private Orders order;
+    private Order order;
 }

--- a/server/src/main/java/com/onetool/server/api/payments/business/PaymentBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/payments/business/PaymentBusiness.java
@@ -25,7 +25,7 @@ public class PaymentBusiness {
 
     @Transactional(readOnly = true)
     public List<PaymentResponse> getPaymentList(Long userId) {
-        List<Order> orderList = orderService.findAllByUserId(userId);
+        List<Order> orderList = orderService.findAll(userId);
         return orderList.stream()
                 .map(paymentService::findByOrders)
                 .filter(Objects::nonNull)

--- a/server/src/main/java/com/onetool/server/api/payments/business/PaymentBusiness.java
+++ b/server/src/main/java/com/onetool/server/api/payments/business/PaymentBusiness.java
@@ -1,6 +1,6 @@
 package com.onetool.server.api.payments.business;
 
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.api.order.service.OrderService;
 import com.onetool.server.api.payments.domain.Payment;
 import com.onetool.server.api.payments.dto.PaymentRequest;
@@ -25,8 +25,8 @@ public class PaymentBusiness {
 
     @Transactional(readOnly = true)
     public List<PaymentResponse> getPaymentList(Long userId) {
-        List<Orders> ordersList = orderService.findAllByUserId(userId);
-        return ordersList.stream()
+        List<Order> orderList = orderService.findAllByUserId(userId);
+        return orderList.stream()
                 .map(paymentService::findByOrders)
                 .filter(Objects::nonNull)
                 .map(PaymentResponse::from)

--- a/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
+++ b/server/src/main/java/com/onetool/server/api/payments/domain/Payment.java
@@ -1,6 +1,6 @@
 package com.onetool.server.api.payments.domain;
 
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -28,8 +28,8 @@ public class Payment extends BaseEntity {
     private Long totalPrice;
 
     @OneToOne
-    @JoinColumn(name = "orders_id")
-    private Orders orders;
+    @JoinColumn(name = "order_id")
+    private Order order;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;

--- a/server/src/main/java/com/onetool/server/api/payments/dto/PaymentRequest.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/PaymentRequest.java
@@ -21,7 +21,7 @@ public record PaymentRequest(
                 .accountName(request.accountName())
                 .bankName(request.bankName())
                 .totalPrice(request.totalPrice())
-                .order(orderService.findOrderById(request.orderId()))
+                .order(orderService.findOne(request.orderId()))
                 .build();
     }
 }

--- a/server/src/main/java/com/onetool/server/api/payments/dto/PaymentRequest.java
+++ b/server/src/main/java/com/onetool/server/api/payments/dto/PaymentRequest.java
@@ -21,7 +21,7 @@ public record PaymentRequest(
                 .accountName(request.accountName())
                 .bankName(request.bankName())
                 .totalPrice(request.totalPrice())
-                .orders(orderService.findOrdersById(request.orderId()))
+                .order(orderService.findOrderById(request.orderId()))
                 .build();
     }
 }

--- a/server/src/main/java/com/onetool/server/api/payments/repository/PaymentRepository.java
+++ b/server/src/main/java/com/onetool/server/api/payments/repository/PaymentRepository.java
@@ -1,6 +1,6 @@
 package com.onetool.server.api.payments.repository;
 
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.api.payments.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-    @Query("SELECT p FROM Payment p WHERE p.orders = :orders")
-    Payment findByOrders(@Param("orders") Orders orders);
+    @Query("SELECT p FROM Payment p WHERE p.order = :order")
+    Payment findByOrders(@Param("order") Order order);
 }

--- a/server/src/main/java/com/onetool/server/api/payments/service/PaymentService.java
+++ b/server/src/main/java/com/onetool/server/api/payments/service/PaymentService.java
@@ -1,6 +1,6 @@
 package com.onetool.server.api.payments.service;
 
-import com.onetool.server.api.order.Orders;
+import com.onetool.server.api.order.Order;
 import com.onetool.server.api.payments.domain.Payment;
 import com.onetool.server.api.payments.repository.PaymentRepository;
 import com.onetool.server.global.new_exception.exception.ApiException;
@@ -18,8 +18,8 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
 
     @Transactional(readOnly = true)
-    public Payment findByOrders(Orders orders) {
-        return paymentRepository.findByOrders(orders);
+    public Payment findByOrders(Order order) {
+        return paymentRepository.findByOrders(order);
     }
 
     @Transactional(readOnly = true)

--- a/server/src/test/java/com/onetool/server/Util/AssignUtil.java
+++ b/server/src/test/java/com/onetool/server/Util/AssignUtil.java
@@ -1,0 +1,28 @@
+package com.onetool.server.Util;
+
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.order.Order;
+import com.onetool.server.api.order.OrderBlueprint;
+import org.springframework.expression.spel.ast.Assign;
+
+import static com.onetool.server.api.order.fixture.OrderBlueprintFixture.createOrderBlueprint;
+
+public class AssignUtil {
+
+    public static OrderBlueprint createAndAssignOrderBlueprint(Long orderBlueprintId, Order order, Blueprint blueprint) {
+        OrderBlueprint orderBlueprint = createOrderBlueprint(orderBlueprintId);
+        orderBlueprint.assignOrder(order);
+        orderBlueprint.assignBlueprint(blueprint);
+        return orderBlueprint;
+    }
+
+    public static void assignMemberToOrder(Order order, Member member) {
+        order.assignMember(member);
+    }
+
+    public static void assignOrderMemberBlueprint(Order order, Member member, Blueprint blueprint, Long orderBlueprintId) {
+        OrderBlueprint orderBlueprint = createAndAssignOrderBlueprint(orderBlueprintId, order, blueprint);
+        assignMemberToOrder(order, member);
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/blueprint/fixture/BlueprintFixture.java
+++ b/server/src/test/java/com/onetool/server/api/blueprint/fixture/BlueprintFixture.java
@@ -1,0 +1,20 @@
+package com.onetool.server.api.blueprint.fixture;
+
+import com.onetool.server.api.blueprint.Blueprint;
+
+import java.util.ArrayList;
+
+public class BlueprintFixture {
+
+    public static Blueprint createBluePrint(Long id){
+        return Blueprint.builder()
+                .id(id)
+                .blueprintName("테스트도면")
+                .creatorName("테스트도면작성자")
+                .downloadLink("Test.uri")
+                .salePrice(1000L)
+                .standardPrice(10000L)
+                .orderBlueprints(new ArrayList<>())
+                .build();
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/helper/MockBeanInjection.java
+++ b/server/src/test/java/com/onetool/server/api/helper/MockBeanInjection.java
@@ -2,8 +2,10 @@ package com.onetool.server.api.helper;
 
 import com.onetool.server.api.member.business.MemberBusiness;
 import com.onetool.server.api.member.service.MemberService;
+import com.onetool.server.api.order.business.OrderBusiness;
 import com.onetool.server.api.qna.business.QnaBoardBusiness;
 import com.onetool.server.global.auth.jwt.JwtUtil;
+import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
@@ -17,4 +19,6 @@ public class MockBeanInjection {
     protected MemberBusiness memberBusiness;
     @MockBean
     protected QnaBoardBusiness qnaBoardBusiness;
+    @MockBean
+    protected OrderBusiness orderBusiness;
 }

--- a/server/src/test/java/com/onetool/server/api/member/fixture/MemberFixture.java
+++ b/server/src/test/java/com/onetool/server/api/member/fixture/MemberFixture.java
@@ -33,6 +33,7 @@ public class MemberFixture {
                 .phoneNum("01000000000")
                 .field("BACKEND")
                 .isNative(true)
+                .orders(new ArrayList<>())
                 .build();
     }
 

--- a/server/src/test/java/com/onetool/server/api/order/business/OrderBusinessTest.java
+++ b/server/src/test/java/com/onetool/server/api/order/business/OrderBusinessTest.java
@@ -1,0 +1,118 @@
+package com.onetool.server.api.order.business;
+
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.blueprint.fixture.BlueprintFixture;
+import com.onetool.server.api.blueprint.service.BlueprintService;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.fixture.MemberFixture;
+import com.onetool.server.api.member.service.MemberService;
+import com.onetool.server.api.order.Order;
+import com.onetool.server.api.order.OrderBlueprint;
+import com.onetool.server.api.order.dto.response.MyPageOrderResponse;
+import com.onetool.server.api.order.fixture.OrderBlueprintFixture;
+import com.onetool.server.api.order.fixture.OrderFixture;
+import com.onetool.server.api.order.service.OrderService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.onetool.server.Util.AssignUtil.assignOrderMemberBlueprint;
+import static com.onetool.server.api.blueprint.fixture.BlueprintFixture.*;
+import static com.onetool.server.api.member.fixture.MemberFixture.*;
+import static com.onetool.server.api.order.fixture.OrderFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderBusinessTest {
+    @Mock
+    private OrderService orderService;
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private BlueprintService blueprintService;
+
+    @InjectMocks
+    private OrderBusiness orderBusiness;
+
+    @Test
+    void 주문을_추가한다() {
+        // ✅ Given (설정)
+        Member member = createMember();
+        String userEmail = "user@example.com";
+        Set<Long> blueprintIdx = Set.of(1L, 2L);
+
+        Blueprint bluePrint1 = createBluePrint(1L);
+        Blueprint bluePrint2 = createBluePrint(2L);
+
+        List<Blueprint> bluePrintList = List.of(bluePrint1, bluePrint2);
+
+        when(memberService.findOne(userEmail)).thenReturn(member);
+        when(blueprintService.findAllBlueprintByIds(blueprintIdx)).thenReturn(bluePrintList);
+        when(orderService.saveOrder(any(Order.class), eq(member), eq(bluePrintList))).thenReturn(100L);
+
+        // ✅ When (실행)
+        Long result = orderBusiness.createOrder(userEmail, blueprintIdx);
+
+        // ✅ Then (검증)
+        assertThat(result).isEqualTo(100L);
+        verify(orderService).saveOrder(any(Order.class), eq(member), eq(bluePrintList));
+    }
+
+    @Test
+    void 유저의_주문목록을_보여준다() {
+        // ✅ Given (설정)
+        Long userId = 2L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Member member = createMember();
+        Order order1 = createOrder(1L);
+        Order order2 = createOrder(2L);
+
+        Blueprint bluePrint1 = createBluePrint(1L);
+        Blueprint bluePrint2 = createBluePrint(2L);
+        List<Blueprint> blueprintList = List.of(bluePrint1, bluePrint2);
+
+        assignOrderMemberBlueprint(order1, member, bluePrint1, 1L);
+        assignOrderMemberBlueprint(order2, member, bluePrint2, 2L);
+
+        List<Order> orders = List.of(order1, order2); // Ensure orders is not empty
+        Page<Order> ordersList = new PageImpl<>(orders);
+
+        // ✅ When (실행)
+        when(memberService.findOneWithCart(userId)).thenReturn(member);
+        when(orderService.findAll(member.getId(), pageable)).thenReturn(ordersList);
+        when(blueprintService.findAll()).thenReturn(blueprintList);
+
+        List<MyPageOrderResponse> myPageOrderResponseList = orderBusiness.getMyPageOrderResponseList(userId, pageable);
+        // ✅ Then (검증)
+        assertThat(myPageOrderResponseList.size()).isEqualTo(2);
+        assertThat(myPageOrderResponseList.get(0).orderId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 주문을_삭제한다() {
+        // ✅ Given (설정)
+        Order order = createOrder(1L);
+        when(orderService.findOne(order.getId())).thenReturn(order);
+
+        // ✅ When (실행)
+        orderBusiness.removeOrder(1L);
+
+        // ✅ Then (검증)
+        verify(orderService).deleteOrder(order);
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/order/controller/OrderControllerTest.java
+++ b/server/src/test/java/com/onetool/server/api/order/controller/OrderControllerTest.java
@@ -1,0 +1,123 @@
+package com.onetool.server.api.order.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onetool.server.api.helper.MockBeanInjection;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.member.fixture.MemberFixture;
+import com.onetool.server.api.member.fixture.WithMockPrincipalDetails;
+import com.onetool.server.api.order.controller.OrderController;
+import com.onetool.server.api.order.dto.request.OrderRequest;
+import com.onetool.server.api.order.dto.response.MyPageOrderResponse;
+import com.onetool.server.global.auth.login.PrincipalDetails;
+import com.onetool.server.global.exception.ApiResponse;
+import jakarta.validation.Valid;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.onetool.server.api.order.fixture.OrderFixture.createMyPageOrderResponse;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(controllers = OrderController.class)
+@AutoConfigureMockMvc
+public class OrderControllerTest extends MockBeanInjection {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 주문을_요청받고_등록한다() throws Exception {
+        // ✅ Given (설정)
+        Member member = MemberFixture.createMember();
+        OrderRequest orderRequest = new OrderRequest(Set.of(1L, 2L));
+        String jsonRequest = objectMapper.writeValueAsString(orderRequest);
+
+        when(orderBusiness.createOrder(anyString(), anySet())).thenReturn(1L);
+
+        // ✅ When (실행)
+        ResultActions result = mockMvc
+                .perform(post("/orders")
+                        .content(jsonRequest)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON));
+
+        // ✅ Then (검증)
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(1L));
+    }
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 주문목록을_조회한다() throws Exception {
+        // ✅ Given (설정)
+        Pageable pageable = PageRequest.of(0, 10);
+        MyPageOrderResponse myPageOrderResponse1 = createMyPageOrderResponse();
+        MyPageOrderResponse myPageOrderResponse2 = createMyPageOrderResponse();
+        when(orderBusiness.getMyPageOrderResponseList(anyLong(), eq(pageable))).thenReturn(List.of(myPageOrderResponse1, myPageOrderResponse2));
+
+        // ✅ When (실행)
+        ResultActions resultActions = mockMvc.perform(
+                get("/orders")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("page", "0")
+                        .param("size", "10")
+        );
+
+        // ✅ Then (검증)
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.size()").value(2))
+                .andExpect(jsonPath("$.result[0].orderId").value(myPageOrderResponse1.orderId()));
+
+        verify(orderBusiness).getMyPageOrderResponseList(eq(2L), eq(pageable));
+    }
+
+    @Test
+    @WithMockPrincipalDetails(id = 2L)
+    void 주문목록을_삭제한다() throws Exception {
+        // ✅ Given (설정)
+        Long orderId = 1L;
+        String jsonBody = objectMapper.writeValueAsString(orderId);
+        doNothing().when(orderBusiness).removeOrder(orderId);
+
+        // ✅ When (실행)
+        ResultActions result = mockMvc.perform(
+                delete("/orders")
+                        .content(jsonBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+        );
+
+        // ✅ Then (검증)
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(1L));
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/order/fake/FakeOrderRepository.java
+++ b/server/src/test/java/com/onetool/server/api/order/fake/FakeOrderRepository.java
@@ -1,0 +1,79 @@
+package com.onetool.server.api.order.fake;
+
+import com.onetool.server.api.order.Order;
+import com.onetool.server.api.order.repository.OrderRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+public class FakeOrderRepository implements OrderRepository {
+    private Long sequence = 1L;
+    private final Map<Long, Order> store = new HashMap<>();
+
+    @Override
+    public Optional<Order> findById(Long id) {
+
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Order save(Order order) {
+        if(order.getId()==null){
+            setIdByReflection(order,sequence++);
+        }
+        store.put(order.getId(),order);
+        return order;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        store.remove(id);
+    }
+
+    @Override
+    public List<Order> findAllByMemberId(Long memberId) {
+        return store.values().stream()
+                .filter(order-> order.getMember().getId().equals(memberId)
+                ).toList();
+    }
+
+    @Override
+    public Page<Order> findAllByMemberId(Long memberId, Pageable pageable) {
+        List<Order> filtered = store.values().stream()
+                .filter(order -> order.getMember().getId().equals(memberId))
+                .sorted(getComparator(pageable.getSort()))
+                .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+
+        List<Order> pageContent = filtered.subList(start, end);
+        return new PageImpl<>(pageContent, pageable, filtered.size());
+    }
+
+    private Comparator<Order> getComparator(Sort sort) {
+        Comparator<Order> comparator = Comparator.comparing(Order::getId);
+
+        for (Sort.Order order : sort) {
+            if (order.getProperty().equals("id")) {
+                Comparator<Order> idComparator = Comparator.comparing(Order::getId);
+                comparator = order.isDescending() ? idComparator.reversed() : idComparator;
+            }
+        }
+        return comparator;
+    }
+
+    private void setIdByReflection(Order order, Long id) {
+        try {
+            Field field = Order.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(order, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/order/fixture/OrderBlueprintFixture.java
+++ b/server/src/test/java/com/onetool/server/api/order/fixture/OrderBlueprintFixture.java
@@ -1,0 +1,13 @@
+package com.onetool.server.api.order.fixture;
+
+import com.onetool.server.api.order.OrderBlueprint;
+
+public class OrderBlueprintFixture {
+
+    public static OrderBlueprint createOrderBlueprint(Long id){
+        return OrderBlueprint.builder()
+                .id(id)
+                .downloadUrl("Test.url")
+                .build();
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/order/fixture/OrderFixture.java
+++ b/server/src/test/java/com/onetool/server/api/order/fixture/OrderFixture.java
@@ -1,0 +1,34 @@
+package com.onetool.server.api.order.fixture;
+
+import com.onetool.server.api.order.Order;
+import com.onetool.server.api.order.dto.response.MyPageOrderResponse;
+import com.onetool.server.api.payments.domain.PaymentStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OrderFixture {
+
+    public static Order createOrder(){
+        return Order.builder()
+                .totalCount(1)
+                .totalPrice(1000L)
+                .status(PaymentStatus.PAY_DONE)
+                .build();
+    }
+
+    public static Order createOrder(Long id){
+        return Order.builder()
+                .id(id)
+                .totalCount(1)
+                .totalPrice(1000L)
+                .status(PaymentStatus.PAY_DONE)
+                .orderItems(new ArrayList<>())
+                .build();
+    }
+
+    public static MyPageOrderResponse createMyPageOrderResponse(){
+        return new MyPageOrderResponse("테스트주문",1L,1000L,"테스트상태",List.of("testuri"));
+
+    }
+}

--- a/server/src/test/java/com/onetool/server/api/order/service/OrderServiceTest.java
+++ b/server/src/test/java/com/onetool/server/api/order/service/OrderServiceTest.java
@@ -1,53 +1,175 @@
 package com.onetool.server.api.order.service;
 
-import com.onetool.server.api.order.dto.response.OrderResponse;
-import org.junit.jupiter.api.DisplayName;
+import com.onetool.server.api.blueprint.Blueprint;
+import com.onetool.server.api.member.domain.Member;
+import com.onetool.server.api.order.Order;
+import com.onetool.server.api.order.fake.FakeOrderRepository;
+import com.onetool.server.global.new_exception.exception.ApiException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.onetool.server.api.blueprint.fixture.BlueprintFixture.*;
+import static com.onetool.server.api.member.fixture.MemberFixture.*;
+import static com.onetool.server.api.order.fixture.OrderFixture.*;
+import static org.assertj.core.api.Assertions.*;
 
-//@SpringBootTest
-//@ActiveProfiles({"test", "local"})
-//class OrderServiceTest {
-//
-//    @Autowired
-//    private OrderService orderService;
-//
-//    @Test
-//    @DisplayName("주문 생성")
-//    void createOrderTest() {
-//        // given
-//
-//        // when
-//        Long orderId = createOrder();
-//        List<OrderResponse. MyPageOrderResponseDto> response
-//                = orderService.getMyPageOrder(OrderFixture.ADMIN_EMAIL);
-//
-//        // then
-//        assertThat(response.size()).isEqualTo(1);
-//    }
-//
-//    @Test
-//    @DisplayName("주문 삭제")
-//    void deleteOrderTest() {
-//        // given
-//        Long orderId = createOrder();
-//
-//        // when
-//        orderService.deleteOrder(orderId);
-//
-//        // then
-//        List<OrderResponse. MyPageOrderResponseDto> response
-//                = orderService.getMyPageOrder(OrderFixture.ADMIN_EMAIL);
-//        assertThat(response.size()).isEqualTo(0);
-//    }
-//
-//    private Long createOrder() {
-//        return orderService.saveOrder(OrderFixture.ADMIN_EMAIL, OrderFixture.ORDER_REQUEST);
-//    }
-//}
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    private OrderService orderService;
+    private FakeOrderRepository orderRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository = new FakeOrderRepository();
+        orderService = new OrderService(orderRepository);
+        initTestOrders();
+    }
+
+    private void initTestOrders() {
+        Member member = createMember();
+        Order order1 = createOrder(1L);
+        Order order2 = createOrder(2L);
+        Order order3 = createOrder(3L);
+
+        Stream.of(order1, order2, order3).forEach(order -> {
+            order.assignMember(member);
+            orderRepository.save(order);
+        });
+
+        this.member = member;
+    }
+
+    @Test
+    void 사용자의_주문목록을_오름차순_페이징_조회한다() {
+        // ✅ Given (설정)
+        Pageable pageable = PageRequest.of(0, 2, Sort.by("id").ascending()); //3개의 객체를 등록하지만 2개의 갯수만 가져오는 페이지
+
+        // ✅ When (실행)
+        Page<Order> orders = orderService.findAll(member.getId(), pageable);
+
+        // ✅ Then (검증)
+        assertThat(orders).hasSize(2);
+        assertThat(orders.getContent().get(0).getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 사용자의_주문목록을_내림차순_페이징_조회한다() {
+        // ✅ Given (설정)
+        Pageable pageable = PageRequest.of(0, 2, Sort.by("id").descending()); //3개의 객체를 등록하지만 2개의 갯수만 가져오는 페이지
+
+        // ✅ When (실행)
+        Page<Order> orders = orderService.findAll(member.getId(), pageable);
+
+        // ✅ Then (검증)
+        assertThat(orders).hasSize(2);
+        assertThat(orders.getContent().get(0).getId()).isEqualTo(3L); //현재 데이터의 마지막 pk값이 3L이다.
+    }
+
+
+    @Test
+    void 상품을_조회한다() {
+        // ✅ Given (설정)
+        Order order = orderRepository.findById(1L).get();
+
+        // ✅ When (실행)
+        Order findOrder = orderService.findOne(order.getId());
+
+        // ✅ Then (검증)
+        assertThat(findOrder.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 상품_조회시_해당_상품이_없으면_실패한다() {
+        // ✅ Given (설정)
+        Long nonexistentOrderId = 999L;
+
+        // ✅ When (실행) && ✅ Then (검증)
+        assertThatThrownBy(() -> orderService.findOne(nonexistentOrderId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage("orderId : 999");
+    }
+
+    @Test
+    void 상품을_저장한다() {
+        // ✅ Given (설정)
+        Order order = orderRepository.findById(1L).get();
+        Blueprint bluePrint1 = createBluePrint(1L); //downLoadLink == Test.uri
+        Blueprint bluePrint2 = createBluePrint(2L);
+
+        // ✅ When (실행)
+        Long orderId = orderService.saveOrder(order, member, List.of(bluePrint1, bluePrint2));
+        Optional<Order> findOrder = orderRepository.findById(orderId);
+
+        // ✅ Then (검증)
+        assertThat(findOrder).isNotNull();
+        assertThat(findOrder.get().getMember().getId()).isEqualTo(2L);
+        assertThat(findOrder.get().getOrderItems().get(0).getDownloadUrl()).isEqualTo("Test.uri");
+    }
+
+    @Test
+    void 상품_저장시_Order가_Null이면_에러를_발생한다() {
+        // ✅ Given (설정)
+        Order order = null;
+        Member member = createMember();//id ==2L
+        Blueprint bluePrint1 = createBluePrint(1L); //downLoadLink == Test.uri
+        Blueprint bluePrint2 = createBluePrint(2L);
+
+        // ✅ When (실행) && ✅ Then (검증)
+        assertThatThrownBy(() -> orderService.saveOrder(order, member, List.of(bluePrint1, bluePrint2)))
+                .isInstanceOf(ApiException.class)
+                .hasMessage("Orders 객체가 NULL입니다.");
+
+    }
+
+    @Test
+    void 주문목록을_삭제한다() {
+        // ✅ Given (설정)
+        Order order = orderRepository.findById(1L).get();
+
+        // ✅ When (실행)
+        orderService.deleteOrder(order);
+        List<Order> orders = orderService.findAll(member.getId());
+
+        // ✅ Then (검증)
+        assertThat(orders).hasSize(2);
+        assertThat(orders.get(0).getId()).isEqualTo(2L);
+    }
+
+    @Test
+    void 주문_객체가_NULL이면_에러를_발생한다() {
+        // ✅ Given (설정)
+        Order order = null;
+
+        // ✅ When (실행) && ✅ Then (검증)
+        assertThatThrownBy(() -> orderService.deleteOrder(order))
+                .isInstanceOf(ApiException.class)
+                .hasMessage("Orders 객체가 NULL입니다.");
+    }
+
+    @Test
+    void 유저의_모든_주문목록을_조회한다() {
+        // ✅ Given (설정)
+        Long userId = member.getId();
+
+        // ✅ When (실행)
+        List<Order> resultOrders = orderService.findAll(userId);
+
+        // ✅ Then (검증)
+        assertThat(resultOrders).hasSize(3);
+        assertThat(resultOrders.get(0).getId()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈
[test: Mockito를 이용한 레이어별 테스트 코드 작성](#210)
- close #이슈번호


## 🔎 작업 내용
MemberFixture 생성
FakeRepository를 이용한 Service 테스트 코드 작성
Mockito를 이용한 Business 테스트 코드 작성
Mockito를 이용한 Controller 테스트 코드 작성
MockBeanInjection 에 OrderBusiness 추가

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
팩터리 메소드의 단위테스트에 대해 많은 고민이 있었습니다.

```
  @Transactional
    public List<MyPageOrderResponse> getMyPageOrderResponseList(Long userId, Pageable pageable) {
        Member member = memberService.findOneWithCart(userId);
        Page<Order> ordersList = orderService.findAll(member.getId(), pageable);
        List<Blueprint> blueprintList = blueprintService.findAll();
        return MyPageOrderResponse.from(ordersList.getContent());
    }
```

MyPageOrderRepsonse.from() 이 함수는 static 으로 선언되어 있어 단위테스트시 Mock 처리가 매우 까다로웠습니다.
Mock을 이용한 단위테스트는 from 메소드 내부구현은 신경쓰지 않고 어떤 로직이 잘 처리되는지 정도만 검증한다고 알고 있습니다. 잘못된 지식이라면 피드백 감사드립니다.

근데 저 팩터리 메소드 하나로인해 저 로직을 실행하기 위한 객체들의 연관관계 및 생성을 직접 다 시켜준 뒤 테스트 해야되는 번거로움이 있었습니다.

혹시 해결 방법에 대해 고민해 보셨는지 궁금합니다 ㅠㅠ 

### Mock 테세트에 대한 저의 지식이 부족한 걸 수도 있어서 피드백 언제든지 환영합니다.


## 🧲 참고 자료 및 공유 사항


