### PR TITLE
feat(chat): 채팅 시스템 및 MessageQueue 도입

### DIFF
--- a/server/src/main/java/com/onetool/server/ServerApplication.java
+++ b/server/src/main/java/com/onetool/server/ServerApplication.java
@@ -2,8 +2,10 @@ package com.onetool.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @SpringBootApplication
 @EnableScheduling
 public class ServerApplication {

--- a/server/src/main/java/com/onetool/server/api/chat/domain/ChatMessage.java
+++ b/server/src/main/java/com/onetool/server/api/chat/domain/ChatMessage.java
@@ -10,11 +10,18 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@SequenceGenerator(
+        name = "CHAT_MESSAGE_SEQ_GENERATOR",
+        sequenceName = "CHAT_MESSAGE_SEQ",
+        initialValue = 1, allocationSize = 100
+)
 public class ChatMessage extends BaseEntity {
 
-    // ✅ PostgreSQL(MySQL 포함)용 ID (Primary Key)
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "CHAT_MESSAGE_SEQ_GENERATOR"
+    )
     private Long id;
     private boolean persisted;
     @Enumerated(EnumType.STRING)

--- a/server/src/main/java/com/onetool/server/api/chat/domain/ChatMessageQueue.java
+++ b/server/src/main/java/com/onetool/server/api/chat/domain/ChatMessageQueue.java
@@ -1,0 +1,46 @@
+package com.onetool.server.api.chat.domain;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+
+public class ChatMessageQueue {
+    private final Queue<ChatMessage> messageQueue = new ConcurrentLinkedQueue<>();
+    private static final int BATCH_SIZE = 10;
+
+    public void addMessage(ChatMessage message) {
+        messageQueue.offer(message);
+    }
+
+    public List<ChatMessage> getUnpersistedMessages() {
+        return messageQueue.stream()
+                .filter(message -> !message.isPersisted())
+                .collect(Collectors.toList());
+    }
+
+    public List<ChatMessage> getQueuedMessages(String roomId) {
+        return messageQueue.stream()
+                .filter(message -> message.getRoomId().equals(roomId))
+                .collect(Collectors.toList());
+    }
+
+    public void markMessagesAsPersisted(List<ChatMessage> messages) {
+        messages.forEach(message -> message.setPersisted(true));
+        // 저장된 메시지는 큐에서 제거
+        messageQueue.removeIf(ChatMessage::isPersisted);
+    }
+
+    public boolean hasEnoughMessages() {
+        return getUnpersistedMessages().size() >= BATCH_SIZE;
+    }
+
+    public int getQueueSize() {
+        return messageQueue.size();
+    }
+
+    public static int getBatchSize() {
+        return BATCH_SIZE;
+    }
+
+}

--- a/server/src/main/java/com/onetool/server/api/chat/domain/ChatMessageQueue.java
+++ b/server/src/main/java/com/onetool/server/api/chat/domain/ChatMessageQueue.java
@@ -1,10 +1,13 @@
 package com.onetool.server.api.chat.domain;
 
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
+@Component
 public class ChatMessageQueue {
     private final Queue<ChatMessage> messageQueue = new ConcurrentLinkedQueue<>();
     private static final int BATCH_SIZE = 10;

--- a/server/src/main/java/com/onetool/server/api/chat/handler/TestChatWebSocketHandler.java
+++ b/server/src/main/java/com/onetool/server/api/chat/handler/TestChatWebSocketHandler.java
@@ -2,6 +2,7 @@ package com.onetool.server.api.chat.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onetool.server.api.chat.domain.ChatMessageQueue;
+import com.onetool.server.api.chat.service.ChatProcessService;
 import com.onetool.server.api.chat.service.ChatService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
@@ -10,8 +11,8 @@ import org.springframework.web.socket.WebSocketSession;
 @Component
 public class TestChatWebSocketHandler extends ChatWebSocketHandler {
 
-    public TestChatWebSocketHandler(ObjectMapper objectMapper, ChatService chatService, ChatMessageQueue chatMessageQueue) {
-        super(objectMapper, chatService, chatMessageQueue);
+    public TestChatWebSocketHandler(ObjectMapper objectMapper, ChatService chatService, ChatProcessService chatProcessService, ChatMessageQueue chatMessageQueue) {
+        super(objectMapper, chatService, chatProcessService, chatMessageQueue);
     }
 
     public void handleTextMessageForTest(WebSocketSession session, TextMessage message) throws Exception {

--- a/server/src/main/java/com/onetool/server/api/chat/handler/TestChatWebSocketHandler.java
+++ b/server/src/main/java/com/onetool/server/api/chat/handler/TestChatWebSocketHandler.java
@@ -1,0 +1,20 @@
+package com.onetool.server.api.chat.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onetool.server.api.chat.domain.ChatMessageQueue;
+import com.onetool.server.api.chat.service.ChatService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+@Component
+public class TestChatWebSocketHandler extends ChatWebSocketHandler {
+
+    public TestChatWebSocketHandler(ObjectMapper objectMapper, ChatService chatService, ChatMessageQueue chatMessageQueue) {
+        super(objectMapper, chatService, chatMessageQueue);
+    }
+
+    public void handleTextMessageForTest(WebSocketSession session, TextMessage message) throws Exception {
+        super.handleTextMessage(session, message);
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/chat/repository/ChatMysqlSpringImpl.java
+++ b/server/src/main/java/com/onetool/server/api/chat/repository/ChatMysqlSpringImpl.java
@@ -23,6 +23,11 @@ public class ChatMysqlSpringImpl implements ChatRepository {
     }
 
     @Override
+    public List<ChatMessage> saveAll(List<ChatMessage> chatMessages) {
+        return delegate.saveAll(chatMessages);
+    }
+
+    @Override
     public void deleteExpiredChatMessagesBefore(LocalDateTime cutoff) {
         delegate.deleteExpiredChatMessagesBefore(cutoff);
     }

--- a/server/src/main/java/com/onetool/server/api/chat/repository/ChatPostgresRepositoryImpl.java
+++ b/server/src/main/java/com/onetool/server/api/chat/repository/ChatPostgresRepositoryImpl.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
+@Primary
 @Repository("chatPostgresRepositoryImpl")
 @RequiredArgsConstructor
 public class ChatPostgresRepositoryImpl implements ChatRepository {

--- a/server/src/main/java/com/onetool/server/api/chat/repository/ChatPostgresRepositoryImpl.java
+++ b/server/src/main/java/com/onetool/server/api/chat/repository/ChatPostgresRepositoryImpl.java
@@ -27,6 +27,11 @@ public class ChatPostgresRepositoryImpl implements ChatRepository {
     }
 
     @Override
+    public List<ChatMessage> saveAll(List<ChatMessage> chatMessages) {
+        return delegate.saveAll(chatMessages);
+    }
+
+    @Override
     public void deleteExpiredChatMessagesBefore(LocalDateTime cutoff) {
         delegate.deleteByCreatedAtBefore(cutoff);
     }

--- a/server/src/main/java/com/onetool/server/api/chat/repository/ChatPostgresRepositoryImpl.java
+++ b/server/src/main/java/com/onetool/server/api/chat/repository/ChatPostgresRepositoryImpl.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
-@Primary
 @Repository("chatPostgresRepositoryImpl")
 @RequiredArgsConstructor
 public class ChatPostgresRepositoryImpl implements ChatRepository {

--- a/server/src/main/java/com/onetool/server/api/chat/repository/ChatRepository.java
+++ b/server/src/main/java/com/onetool/server/api/chat/repository/ChatRepository.java
@@ -13,6 +13,8 @@ public interface ChatRepository {
 
     ChatMessage save(ChatMessage chatMessage);
 
+    List<ChatMessage> saveAll(List<ChatMessage> chatMessages);
+
     void deleteExpiredChatMessagesBefore(LocalDateTime cutoff);
 
     List<ChatMessage> findLatestMessages(Pageable pageable, String roomId);

--- a/server/src/main/java/com/onetool/server/api/chat/service/ChatProcessService.java
+++ b/server/src/main/java/com/onetool/server/api/chat/service/ChatProcessService.java
@@ -1,0 +1,45 @@
+package com.onetool.server.api.chat.service;
+
+import com.onetool.server.api.chat.domain.ChatMessage;
+import com.onetool.server.api.chat.domain.ChatMessageQueue;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatProcessService {
+
+    private final ChatMessageQueue chatMessageQueue;
+    private final ChatService chatService;
+
+    @Async
+    public void processMessageQueue() {
+        List<ChatMessage> unpersistedMessages = chatMessageQueue.getUnpersistedMessages();
+        if (unpersistedMessages.isEmpty()) {
+            return;
+        }
+
+        try {
+            // 배치 사이즈만큼만 처리
+            List<ChatMessage> messagesToPersist = unpersistedMessages.stream()
+                    .limit(ChatMessageQueue.getBatchSize())
+                    .collect(Collectors.toList());
+
+            // DB에 저장
+            Integer messageSize = chatService.saveAllTextMessage(messagesToPersist);
+            log.info("Messages in Queue are saved. size: {}", messageSize);
+
+            // 저장된 메시지 표시 및 큐에서 제거
+            chatMessageQueue.markMessagesAsPersisted(messagesToPersist);
+
+        } catch (Exception e) {
+            log.error("배치 메시지 저장 중 오류 발생", e);
+        }
+    }
+}

--- a/server/src/main/java/com/onetool/server/api/chat/service/ChatProcessService.java
+++ b/server/src/main/java/com/onetool/server/api/chat/service/ChatProcessService.java
@@ -19,7 +19,7 @@ public class ChatProcessService {
     private final ChatService chatService;
 
     @Async
-    public void processMessageQueue() {
+    public synchronized void processMessageQueue() {
         List<ChatMessage> unpersistedMessages = chatMessageQueue.getUnpersistedMessages();
         if (unpersistedMessages.isEmpty()) {
             return;

--- a/server/src/main/java/com/onetool/server/api/chat/service/ChatProcessService.java
+++ b/server/src/main/java/com/onetool/server/api/chat/service/ChatProcessService.java
@@ -19,7 +19,7 @@ public class ChatProcessService {
     private final ChatService chatService;
 
     @Async
-    public synchronized void processMessageQueue() {
+    public void processMessageQueue() {
         List<ChatMessage> unpersistedMessages = chatMessageQueue.getUnpersistedMessages();
         if (unpersistedMessages.isEmpty()) {
             return;

--- a/server/src/main/java/com/onetool/server/api/chat/service/ChatService.java
+++ b/server/src/main/java/com/onetool/server/api/chat/service/ChatService.java
@@ -69,4 +69,5 @@ public class ChatService {
                 .stream().map(ChatMessageResponse::from)
                 .toList();
     }
+
 }

--- a/server/src/main/java/com/onetool/server/api/chat/service/ChatService.java
+++ b/server/src/main/java/com/onetool/server/api/chat/service/ChatService.java
@@ -52,6 +52,12 @@ public class ChatService {
     }
 
     @Transactional
+    public int saveAllTextMessage(List<ChatMessage> chatMessages) {
+        List<ChatMessage> chatMessageList = chatRepository.saveAll(chatMessages);
+        return chatMessageList.size();
+    }
+
+    @Transactional
     public void deleteExpiredChatMessages() {
         LocalDateTime cutoff = LocalDateTime.now().minusDays(3);
         chatRepository.deleteExpiredChatMessagesBefore(cutoff);

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -20,3 +20,7 @@ server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.path=/
 
 management.endpoints.web.exposure.include=info, health, prometheus
+
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.order_insertes=true
+spring.jpa.properties.hibernate.jdbc.batch_size=100

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=server
 
+spring.config.import=optional:application-api.properties
+
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.sql.init.mode=always
@@ -9,12 +11,7 @@ spring.jpa.hibernate.ddl-auto=create
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
-spring.config.import=optional:application-api.properties
-
 logging.level.org.hibernate.type=trace
-
-toss.payment.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
-toss.payment.confirm-url=https://api.tosspayments.com/v1/payments/confirm
 
 server.servlet.session.cookie.same-site=none
 server.servlet.session.cookie.http-only=true
@@ -22,3 +19,7 @@ server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.path=/
 
 management.endpoints.web.exposure.include=info, health, prometheus
+
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.order_insertes=true
+spring.jpa.properties.hibernate.jdbc.batch_size=100

--- a/server/src/test/java/com/onetool/server/api/chat/service/ChatMessageQueueTest.java
+++ b/server/src/test/java/com/onetool/server/api/chat/service/ChatMessageQueueTest.java
@@ -1,0 +1,146 @@
+package com.onetool.server.api.chat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onetool.server.api.chat.domain.ChatMessage;
+import com.onetool.server.api.chat.domain.ChatMessageQueue;
+import com.onetool.server.api.chat.domain.ChatRoom;
+import com.onetool.server.api.chat.domain.MessageType;
+import com.onetool.server.api.chat.handler.TestChatWebSocketHandler;
+import com.onetool.server.api.chat.repository.ChatRepository;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+public class ChatMessageQueueTest {
+
+    @Autowired
+    private TestChatWebSocketHandler chatWebSocketHandler;
+
+    @Autowired
+    private ChatService chatService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ChatRepository chatRepository;
+
+    @Mock
+    private WebSocketSession webSocketSession;
+
+    private ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+        createChatRoom();
+    }
+
+//    @Test
+//    @DisplayName("메시지 처리 시 chatMessageQueue에 메시지가 추가되는지 확인")
+//    void handleTextMessageAddToQueue() throws Exception {
+//        // given
+//        ChatMessage chatMessage = ChatMessage.builder()
+//                .roomId(ChatRoom.roomId)
+//                .sender("테스트 사용자")
+//                .message("테스트 메시지")
+//                .type(MessageType.TALK)
+//                .build();
+//
+//        String messageJson = objectMapper.writeValueAsString(chatMessage);
+//        TextMessage textMessage = new TextMessage(messageJson);
+//
+//        given(chatRepository.save(any())).willReturn(chatMessage);
+//
+//        // when
+//        chatWebSocketHandler.handleTextMessageForTest(webSocketSession, textMessage);
+//
+//        // then
+//        assertThat(chatWebSocketHandler.getChatMessageQueue().getUnpersistedMessages())
+//                .hasSize(1)
+//                .first()
+//                .satisfies(message -> {
+//                    assertThat(message.getRoomId()).isEqualTo(chatMessage.getRoomId());
+//                    assertThat(message.getSender()).isEqualTo(chatMessage.getSender());
+//                    assertThat(message.getMessage()).isEqualTo(chatMessage.getMessage());
+//                    assertThat(message.getType()).isEqualTo(chatMessage.getType());
+//                });
+//    }
+//
+//    @Test
+//    @DisplayName("메시지가 배치 사이즈만큼 쌓이면 자동으로 저장되는지 확인")
+//    void handleBatchSizeMessages() throws Exception {
+//        // given
+//        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+//
+//        // when
+//        for (int i = 0; i < ChatMessageQueue.getBatchSize(); i++) {
+//            ChatMessage chatMessage = ChatMessage.builder()
+//                    .roomId(ChatRoom.roomId)
+//                    .sender("사용자" + i)
+//                    .message("메시지" + i)
+//                    .type(MessageType.TALK)
+//                    .build();
+//
+//            String messageJson = objectMapper.writeValueAsString(chatMessage);
+//            TextMessage textMessage = new TextMessage(messageJson);
+//
+//            chatWebSocketHandler.handleTextMessageForTest(webSocketSession, textMessage);
+//        }
+//
+//        // then
+//        verify(chatService).saveTextMessage(messageCaptor.capture());
+//        assertThat(messageCaptor.getValue()).isNotNull();
+//        assertThat(chatWebSocketHandler.getChatMessageQueue().hasEnoughMessages()).isTrue();
+//    }
+//
+//    @Test
+//    @DisplayName("입장 메시지 처리 확인")
+//    void handleEnterMessage() throws Exception {
+//        // given
+//        ChatMessage chatMessage = ChatMessage.builder()
+//                .roomId(ChatRoom.roomId)
+//                .sender("새로운 사용자")
+//                .type(MessageType.ENTER)
+//                .build();
+//
+//        String messageJson = objectMapper.writeValueAsString(chatMessage);
+//        TextMessage textMessage = new TextMessage(messageJson);
+//
+//        // when
+//        chatWebSocketHandler.handleTextMessageForTest(webSocketSession, textMessage);
+//
+//        // then
+//        assertThat(chatRoom.getSessions()).contains(webSocketSession);
+//        assertThat(chatWebSocketHandler.getChatMessageQueue().getUnpersistedMessages())
+//                .hasSize(1)
+//                .first()
+//                .satisfies(message -> {
+//                    assertThat(message.getMessage()).contains("님이 입장했습니다");
+//                    assertThat(message.getType()).isEqualTo(MessageType.ENTER);
+//                });
+//    }
+
+    private void createChatRoom() {
+        String randomId = UUID.randomUUID().toString();
+        chatRoom = ChatRoom.builder()
+                .roomId(randomId)
+                .name("테스트 이름")
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #230 


## 🔎 작업 내용

원툴의 채팅을 도입하여 도면에 대한 이야기를 하거나 정보를 공유할 수 있는 커뮤니케이션 도구를 개발하려고 한다. 사용성 측면에서 보다 구현이 용이한 공개채팅으로 구현하고자 한다.

# 📚 기술 선택

모놀리식 아키텍처를 통해 서버 비용을 절감하기 위해 별도의 프레임워크가 아닌 기존에 사용중인 Java와 Spring Boot를 사용하기로 결정했다.

### 메시지 처리 방식

1:1이 아닌 다수의 사용자가 동시에 진행할 수 있는 채팅을 구현하기 위해 어떤 메시지 전송 방식이 접합할지 장단점을 구분했다.

| 방식 | 장점 | 단점 |
| --- | --- | --- |
| **HTTP Polling** | 서비스 구현이 간편 | - Polling 주기에 따라 메시지 전송 속도가 결정 <br/> - Polling된 시점에 따라 사용자가 보고 있는 채팅 내용이 결정됨 |
| **WebSocket** | - 모든 시점에서 사용자의 채팅 내용이 일치 <br/> - 여러 사용자에게 동시에 브로드캐스트 가능 | - 연결이 많아지면 복잡한 세션 관리 <br/> - Stateful 방식으로 연결 관리 필요 |
| **gRPC** | - 멀티플렉싱을 통한 동시 요청 처리 <br/> - Protocol Buffers로 타입 안정성 <br/> - 스트리밍 지원 <br/> - 부하분산 내장 | - 브라우저 지원 제한 <br/> - 러닝 커브 존재 <br/> - 브로드캐스팅 부재 (각각 유니캐스트) |

공개 채팅 특성상 브로드캐스트가 간편한 **WebSocket**을 채택했다. 

### 채팅 메시지 저장소

현재 사용 중인 MySQL을 그대로 사용하기로 결정했다. 추후 성능 테스트를 통해 RDB인 MySQL과 Postgres, MongoDB 중 적합한 데이터베이스로 마이그레이션하는 과정을 계획하고 있다.

# 📝 채팅 서비스 흐름

여러 관련 아티클을 조사해본 결과 애플리케이션 간의 원활한 통신을 위해 메시지 브로커를 통해 전송한다고 한다. 대규모 시스템에 대비한 구현이 아닌 MVP가 목적인 만큼 메시지 브로커 사용에 대해선 추후 미루도록 하겠다.

### 일반 채팅

1. 사용자 채팅 서비스 접속 (클라이언트 → 서버)
2. 접속 시, ENTER 메시지 전송 (클라이언트 → 서버)
3. ENTER 메시지의 sender를 확인하여 `환영 메시지` 를 전송 (서버 → 클라이언트들)
4. TALK 메시지를 통해 일반 채팅 메시지 전송 (클라이언트 - >서버)
5. 전달받은 TALK 메시지를 모든 세션에 전송 (서버 → 클라이언트들)
6. 종료 시 QUIT 메시지를 전송 (클라이언트 → 서버)
7. QUIT 메시지의 sender를 확인하여 `퇴장 메시지` 를 전송 (서버 → 클라이언트)

### 채팅 저장 및 조회

1. 사용자가 채팅 서비스 접속 (클라이언트 → 서버)
2. (API) 이전 메시지들을 조회하기 위해 조회 API 콜 (클라이언트 → 서버)
3. (API) DB에서 메시지들 전체 응답 (서버 → 클라이언트)
4. ENTER, TALK, QUIT 채팅 메시지 전송 (클라이언트 → 서버)
5. DB에 메시지를 저장 (서버) 

<aside>
❓

### 모든 메시지를 영구 저장할 것인가?

모든 채팅 메시지는 저장 시 CreatedAt 필드가 자동으로 삽입된다. MySQL의 배치를 통해 특정 시간마다 `CreatedAt + 일정 시간` 인 메시지는 자동으로 삭제되도록 구현한다.

</aside>

# 🤔 기술적 고민 및 구현

## 1. WebSocket는 어떻게 작동하는가?

### WebSocket 내부 과정

서블릿 컨테이너 위에서 동작하기 때문에 표준 HTTP 요청으로 시작하여, WebSocket 프로토콜로 업데이트 하게 된다.

1. 서블릿 컨테이너가 HTTP 요청을 받는다.
2. DispatcherServlet으로 전달된다.
3. 요청 URL을 기반으로 해당 요청을 처리할 핸들러를 찾는다.
    - 이때 MVC 컨트롤러를 먼저 수행 후, WebSocketHandler를 찾는다.
4. 핸드셰이크 요청 수행
5. 연결 확립 후 WebSocketSession으로 관리

DispatcherServlet 위에서 작동하기 때문에 기존 MVC와 동일하게 스레드 풀을 통해 작업을 수행하게 된다.

## 2. 어떤 데이터베이스가 적합할까?

**[ 채팅 시스템의 주요 특징 ]**

- 메시지는 수정 및 삭제가 이루어지지 않고, 저장 및 조회만 발생한다.
- 공개 채팅이기 때문에 대량의 메시지의 저장이 발생할 수 있다고 예상한다. → 데이터의 정합성
- 일정 시간이 지난 메시지는 자동으로 삭제된다.

**[ 읽기/쓰기 연산 패턴 ]**

- 사용자는 최근 메시지 내역을 조회하고, 메시지를 전송한다.
- 읽기:쓰기 비율은 대략 1:1 정도이다.

이 기준으로 미루어봤을 때 NoSQL을 사용하는 것이 올바르다고 생각한다. 그 중 키/값 형식이 아닌 다큐먼트 형식의 MongoDB가 객체 형태인 메시지 구조에 더욱 적합하다고 판단했다.

[데이터베이스 성능 테스트](https://www.notion.so/23064b4a4ab480ed913ed216cc0acab4?pvs=21)

## 3. 채팅 저장 시점을 언제로 해야 하는가?

채팅 메시지가 발생할 때마다 데이터베이스에 접근하여 저장하는 방식은 사용 면에서 DB I/O가 매번 발생하기 때문에 매우 비효율적이라고 판단했다.

따라서, 메시지를 일정 개수만큼 가지고 있다가 한 번에 저장하는 `메시지 큐` 시스템을 도입하는 것이 성능을 향상시킬 수 있다고 판단했다.

그렇게 구축한 아키텍처가 다음과 같다.

<img width="921" height="572" alt="아키텍처" src="https://github.com/user-attachments/assets/6b3c2828-452e-473b-9bd9-1c5bdb1c5e60" />

위 아키텍처의 동작 방식은 다음과 같다.

- 사용자가 메시지를 전송하는 경우
    1. 메시지를 WebSocket으로 전송한다.
    2. Spring에선 해당 메시지를 접속된 Session에게 전송한다.
        1. 해당 메시지는 큐에 저장된다.
    3. Queue에 일정 개수가 저장된 경우, DB에 저장한다.
- 사용자가 접속하는 경우
    1. DB에서 채팅 내역을 조회한다.
    2. Queue에 있는 메시지들을 조회한다.

### 어떤 컬렉션을 사용해야 할까?

처음에는 동시성 처리가 가능한 BlockingQueue를 사용하기로 결정했다.

그런데 사용자가 새로 접속한 경우, Queue에 있는 내용들을 조회할 필요가 발생했다.

따라서, 동시성 처리가 가능하면서 stream이 가능한 컬렉션을 찾던중 `ConcurrentLinkedQueue` 를 사용하게 되었다.

```java
private final Queue<ChatMessage> messageQueue = new ConcurrentLinkedQueue<>();
```

### 쓰레드를 이용하는 이유

예를 들어, 한 명이 메시지를 전송할 경우 큐에 메세지가 담겼는데 큐 사이즈가 가득찼다고 해보자.

만약 해당 스레드에서 DB에 저장하고 큐를 비우는 작업을 수행할 경우,

채팅 메시지 전송 기능이 DB I/O로 인해 지연이 발생한다고 판단했다.

따라서, DB에 저장하고 쓰레드를 비우는 작업은 별도의 쓰레드가 필요하다고 판단했다.

이는 추후 발생하는 Writing timeout 문제와 연관되어 있다.  5번 내용을 참고하면 된다.

## 4. 배포 후 성능 측정

성능 측정 환경

- AWS EC2
    - t3a.small
- AWS RDS
    - PostgreSQL
    - db.t4g.micro

### MessageQueue 도입 전

- 부하 테스트 결과
    
    ```bash
      █ TOTAL RESULTS
    
        checks_total.......................: 1582    7.531281/s
        checks_succeeded...................: 100.00% 1582 out of 1582
        checks_failed......................: 0.00%   0 out of 1582
    
        ✓ chat list API is status 200
    
        HTTP
        http_req_duration.......................................................: avg=8.41s  min=24.76ms med=2.61s  max=55.56s p(90)=22.01s p(95)=34.43s
          { expected_response:true }............................................: avg=8.41s  min=24.76ms med=2.61s  max=55.56s p(90)=22.01s p(95)=34.43s
        http_req_failed.........................................................: 0.00%  0 out of 1582
        http_reqs...............................................................: 1582   7.531281/s
    
        EXECUTION
        iteration_duration......................................................: avg=45.83s min=15.05s  med=39.59s max=2m38s  p(90)=1m12s  p(95)=1m46s
        iterations..............................................................: 1334   6.350651/s
        vus.....................................................................: 918    min=6         max=999
        vus_max.................................................................: 1000   min=1000      max=1000
    
        NETWORK
        data_received...........................................................: 607 MB 2.9 MB/s
        data_sent...............................................................: 5.8 MB 28 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=8.65s  min=13.86ms med=2.05s  max=55.48s p(90)=22.35s p(95)=44.15s
        ws_msgs_received........................................................: 522909 2489.3646/s
        ws_msgs_sent............................................................: 50897  242.300649/s
        ws_session_duration.....................................................: avg=44.52s min=10.2s   med=38.01s max=2m38s  p(90)=1m12s  p(95)=1m46s
        ws_sessions.............................................................: 1989   9.468849/s
    
    running (3m30.1s), 0000/1000 VUs, 1333 complete and 791 interrupted iterations
    default ✓ [======================================] 0917/1000 VUs  3m0s
    ```
    
    ```bash
      █ TOTAL RESULTS
    
        checks_total.......................: 1702    8.105171/s
        checks_succeeded...................: 100.00% 1702 out of 1702
        checks_failed......................: 0.00%   0 out of 1702
    
        ✓ chat list API is status 200
    
        HTTP
        http_req_duration.......................................................: avg=13.41s min=73.63ms med=11.4s  max=43.67s p(90)=32.43s p(95)=36.66s
          { expected_response:true }............................................: avg=13.41s min=73.63ms med=11.4s  max=43.67s p(90)=32.43s p(95)=36.66s
        http_req_failed.........................................................: 0.00%  0 out of 1702
        http_reqs...............................................................: 1702   8.105171/s
    
        EXECUTION
        iteration_duration......................................................: avg=53.96s min=15.14s  med=44.25s max=3m13s  p(90)=1m39s  p(95)=2m14s
        iterations..............................................................: 1575   7.500379/s
        vus.....................................................................: 512    min=6         max=999
        vus_max.................................................................: 1000   min=1000      max=1000
    
        NETWORK
        data_received...........................................................: 1.5 GB 7.0 MB/s
        data_sent...............................................................: 4.7 MB 22 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=7.95s  min=13.41ms med=4.04s  max=29.81s p(90)=25.16s p(95)=28.25s
        ws_msgs_received........................................................: 407713 1941.588471/s
        ws_msgs_sent............................................................: 47388  225.668533/s
        ws_session_duration.....................................................: avg=53s    min=10.23s  med=44.21s max=3m13s  p(90)=1m39s  p(95)=2m14s
        ws_sessions.............................................................: 2087   9.938597/s
    
    running (3m30.0s), 0000/1000 VUs, 1575 complete and 512 interrupted iterations
    default ✓ [======================================] 0512/1000 VUs  3m0s
    ```
    

### MessageQueue 도입 후

- MAX_SIZE = 10
    
    ```bash
      █ TOTAL RESULTS
    
        checks_total.......................: 1598   7.607943/s
        checks_succeeded...................: 98.93% 1581 out of 1598
        checks_failed......................: 1.06%  17 out of 1598
    
        ✗ chat list API is status 200
          ↳  98% — ✓ 1581 / ✗ 17
    
        HTTP
        http_req_duration.......................................................: avg=17.2s  min=16.66ms med=12.64s max=1m0s   p(90)=42.46s p(95)=49.99s
          { expected_response:true }............................................: avg=16.74s min=16.66ms med=12.45s max=59.19s p(90)=41.16s p(95)=48.84s
        http_req_failed.........................................................: 1.06%  17 out of 1598
        http_reqs...............................................................: 1598   7.607943/s
    
        EXECUTION
        iteration_duration......................................................: avg=45.13s min=15.09s  med=36.39s max=2m14s  p(90)=1m25s  p(95)=1m36s
        iterations..............................................................: 1325   6.308213/s
        vus.....................................................................: 891    min=6          max=999
        vus_max.................................................................: 1000   min=1000       max=1000
    
        NETWORK
        data_received...........................................................: 1.2 GB 5.8 MB/s
        data_sent...............................................................: 5.2 MB 25 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=10.07s min=13.66ms med=4.87s  max=55.25s p(90)=35.4s  p(95)=46.08s
        ws_msgs_received........................................................: 484011 2304.335434/s
        ws_msgs_sent............................................................: 43305  206.171442/s
        ws_session_duration.....................................................: avg=44.36s min=10.21s  med=36.41s max=2m14s  p(90)=1m25s  p(95)=1m36s
        ws_sessions.............................................................: 1972   9.388525/s
    
    running (3m30.0s), 0000/1000 VUs, 1323 complete and 741 interrupted iterations
    default ✓ [======================================] 0654/1000 VUs  3m0s
    ```
    
    ```bash
      █ TOTAL RESULTS
    
        checks_total.......................: 1203   5.727484/s
        checks_succeeded...................: 99.83% 1201 out of 1203
        checks_failed......................: 0.16%  2 out of 1203
    
        ✗ chat list API is status 200
          ↳  99% — ✓ 1201 / ✗ 2
    
        HTTP
        http_req_duration.......................................................: avg=15.01s min=23.71ms med=214.05ms max=59.99s p(90)=44.87s p(95)=47.1s
          { expected_response:true }............................................: avg=14.94s min=23.71ms med=206.82ms max=49.42s p(90)=44.78s p(95)=47.06s
        http_req_failed.........................................................: 0.16%  2 out of 1203
        http_reqs...............................................................: 1203   5.727484/s
    
        EXECUTION
        iteration_duration......................................................: avg=52.83s min=15.08s  med=39.64s   max=2m28s  p(90)=1m59s  p(95)=2m8s
        iterations..............................................................: 1098   5.227579/s
        vus.....................................................................: 896    min=6         max=999
        vus_max.................................................................: 1000   min=1000      max=1000
    
        NETWORK
        data_received...........................................................: 422 MB 2.0 MB/s
        data_sent...............................................................: 5.2 MB 25 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=13.97s min=13.88ms med=6.6s     max=49.35s p(90)=39.3s  p(95)=41.85s
        ws_msgs_received........................................................: 494366 2353.676925/s
        ws_msgs_sent............................................................: 43539  207.289214/s
        ws_session_duration.....................................................: avg=51.79s min=10.17s  med=39.11s   max=2m28s  p(90)=1m59s  p(95)=2m8s
        ws_sessions.............................................................: 1799   8.56504/s
    
    running (3m30.0s), 0000/1000 VUs, 1098 complete and 759 interrupted iterations
    default ✓ [======================================] 0863/1000 VUs  3m0s
    ```
    
- MAX_SIZE=20
    
    ```bash
      █ TOTAL RESULTS
    
        checks_total.......................: 1403   6.679315/s
        checks_succeeded...................: 96.57% 1355 out of 1403
        checks_failed......................: 3.42%  48 out of 1403
    
        ✗ chat list API is status 200
          ↳  96% — ✓ 1355 / ✗ 48
    
        HTTP
        http_req_duration.......................................................: avg=20.3s  min=24.35ms med=19.54s max=1m0s   p(90)=50.22s p(95)=58.79s
          { expected_response:true }............................................: avg=18.89s min=24.35ms med=18.34s max=59.65s p(90)=43.9s  p(95)=54.39s
        http_req_failed.........................................................: 3.42%  48 out of 1403
        http_reqs...............................................................: 1403   6.679315/s
    
        EXECUTION
        iteration_duration......................................................: avg=47.44s min=15.06s  med=47.21s max=2m2s   p(90)=1m25s  p(95)=1m33s
        iterations..............................................................: 1153   5.489131/s
        vus.....................................................................: 938    min=6          max=999
        vus_max.................................................................: 1000   min=1000       max=1000
    
        NETWORK
        data_received...........................................................: 1.2 GB 5.7 MB/s
        data_sent...............................................................: 4.7 MB 22 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=12.97s min=15.4ms  med=10.41s max=55.18s p(90)=41.76s p(95)=48.52s
        ws_msgs_received........................................................: 519033 2470.980112/s
        ws_msgs_sent............................................................: 36823  175.304654/s
        ws_session_duration.....................................................: avg=46.51s min=10.21s  med=47.2s  max=2m2s   p(90)=1m25s  p(95)=1m33s
        ws_sessions.............................................................: 1888   8.988273/s
    
    running (3m30.1s), 0000/1000 VUs, 1152 complete and 779 interrupted iterations
    default ✓ [======================================] 0893/1000 VUs  3m0s
    ```
    

## 5. 데이터베이스 쓰기 에러 발생

### 원인

MessageQueue에 있는 메시지들을 DB에 저장하는 코드와 MessageQueue의 저장된 메시지들을 제거하는 함수가 proccessMessageQueue에서 수행된다.

이 경우 저장이 되지 않는 오류가 발생했디.

그 이유는 Hibernate는 엔티티의 ID 필드가 생성 후 변경되면 예외를 던지는데,

병렬 처리 중 같은 엔티티 객체를 재사용하거나 ID를 덮어쓰는 로직이 있을 때 문제가 발생한 것이다.

saveAll()에 넘기는 리스트에 이미 영속 상태인 엔티티와 새로운 엔티티가 섞여 있고, 그 과정에서 Hibernate가 기존 엔티티를 찾았다가 ID 불일치로 예외 발생한다.

병렬 스레드에서 동일 엔티티 인스턴스 공유 ChatProcessService가 멀티스레드로 큐를 소비하고, 같은 ChatMessage 객체를 여러 스레드가 수정하기 때문이다.

### 해결

총 두 가지의 해결 방안으로 정리했다.

1. 저장을 메시지 큐(Kafka, Redis Stream 등)에게 위힘
2. WebSocket 메시지는 즉시 전송, DB 저장은 비동기 처리

이 방법 중 별도의 기술 스택 도입이 필요없는 2번 방법을 사용하기로 결정했다.

현재 Spring Boot에선 @Async를 통해 

스프링은 요청 하나 당 스레드를 만들어줘서 진행하게 되는데, ****@Async 어노테이션을 통해 ****쓰레드풀을 활용한 비동기 메소드를 지원해준다.

메소드에 @Async를 달아두면 비동기로 호출자는 즉시 리턴하고, spring TaskExcutor에 의해 새로운 스레드로 실행되게 된다.

@Async의 경우 Self-Invocation이 불가능하기 때문에 기존 Handler 대신 ChatProcessService 클래스를 만들어 기능을 위임하였다.

```java
@Async
  public void processMessageQueue() {
      List<ChatMessage> unpersistedMessages = chatMessageQueue.getUnpersistedMessages();
      if (unpersistedMessages.isEmpty()) {
          return;
      }

      try {
          // 배치 사이즈만큼만 처리
          List<ChatMessage> messagesToPersist = unpersistedMessages.stream()
                  .limit(ChatMessageQueue.getBatchSize())
                  .collect(Collectors.toList());

          // DB에 저장
          Integer messageSize = chatService.saveAllTextMessage(messagesToPersist);
          log.info("Messages in Queue are saved. size: {}", messageSize);

          // 저장된 메시지 표시 및 큐에서 제거
          chatMessageQueue.markMessagesAsPersisted(messagesToPersist);

      } catch (Exception e) {
          log.error("배치 메시지 저장 중 오류 발생", e);
      }
  }
```

- @Async MAX_SIZE=20
    
    ```java
      █ TOTAL RESULTS
    
        checks_total.......................: 2499    11.898071/s
        checks_succeeded...................: 100.00% 2499 out of 2499
        checks_failed......................: 0.00%   0 out of 2499
    
        ✓ chat list API is status 200
    
        HTTP
        http_req_duration.......................................................: avg=4.2s   min=23.26ms med=1.98s  max=36.6s  p(90)=12.06s p(95)=13.22s
          { expected_response:true }............................................: avg=4.2s   min=23.26ms med=1.98s  max=36.6s  p(90)=12.06s p(95)=13.22s
        http_req_failed.........................................................: 0.00%  0 out of 2499
        http_reqs...............................................................: 2499   11.898071/s
    
        EXECUTION
        iteration_duration......................................................: avg=29.21s min=15.09s  med=19.68s max=2m16s  p(90)=59.13s p(95)=1m28s
        iterations..............................................................: 2381   11.336258/s
        vus.....................................................................: 938    min=6         max=999
        vus_max.................................................................: 1000   min=1000      max=1000
    
        NETWORK
        data_received...........................................................: 979 MB 4.7 MB/s
        data_sent...............................................................: 5.4 MB 26 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=5.65s  min=11.23ms med=1.74s  max=49.79s p(90)=13.22s p(95)=36.48s
        ws_msgs_received........................................................: 494769 2355.660982/s
        ws_msgs_sent............................................................: 43811  208.589995/s
        ws_session_duration.....................................................: avg=27.16s min=10.13s  med=17.38s max=2m16s  p(90)=59.1s  p(95)=1m28s
        ws_sessions.............................................................: 3104   14.778557/s
    
    running (3m30.0s), 0000/1000 VUs, 2381 complete and 757 interrupted iterations
    default ✓ [======================================] 0861/1000 VUs  3m0s
    ```
    
- @Async MAX_SIZE=100
    
    ```java
      █ TOTAL RESULTS
    
        checks_total.......................: 2208    10.512297/s
        checks_succeeded...................: 100.00% 2208 out of 2208
        checks_failed......................: 0.00%   0 out of 2208
    
        ✓ chat list API is status 200
    
        HTTP
        http_req_duration.......................................................: avg=7.69s  min=19.27ms med=4.5s    max=43.39s p(90)=20.92s p(95)=24.44s
          { expected_response:true }............................................: avg=7.69s  min=19.27ms med=4.5s    max=43.39s p(90)=20.92s p(95)=24.44s
        http_req_failed.........................................................: 0.00%  0 out of 2208
        http_reqs...............................................................: 2208   10.512297/s
    
        EXECUTION
        iteration_duration......................................................: avg=41.67s min=15.05s  med=28.95s  max=3m6s   p(90)=1m31s  p(95)=1m53s
        iterations..............................................................: 1908   9.083996/s
        vus.....................................................................: 727    min=6         max=999
        vus_max.................................................................: 1000   min=1000      max=1000
    
        NETWORK
        data_received...........................................................: 1.2 GB 5.6 MB/s
        data_sent...............................................................: 5.0 MB 24 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=4.8s   min=13.53ms med=102.3ms max=25.92s p(90)=15.9s  p(95)=19.47s
        ws_msgs_received........................................................: 511970 2437.491231/s
        ws_msgs_sent............................................................: 52520  250.047931/s
        ws_session_duration.....................................................: avg=39.84s min=10.18s  med=28.86s  max=3m6s   p(90)=1m31s  p(95)=1m53s
        ws_sessions.............................................................: 2634   12.540485/s
    
    running (3m30.0s), 0000/1000 VUs, 1908 complete and 726 interrupted iterations
    default ✓ [======================================] 0726/1000 VUs  3m0s
    ```
    
    ```java
      █ TOTAL RESULTS
    
        checks_total.......................: 1943    9.2498/s
        checks_succeeded...................: 100.00% 1943 out of 1943
        checks_failed......................: 0.00%   0 out of 1943
    
        ✓ chat list API is status 200
    
        HTTP
        http_req_duration.......................................................: avg=11.4s  min=16.23ms med=6.96s  max=50.61s p(90)=31.09s p(95)=39.64s
          { expected_response:true }............................................: avg=11.4s  min=16.23ms med=6.96s  max=50.61s p(90)=31.09s p(95)=39.64s
        http_req_failed.........................................................: 0.00%  0 out of 1943
        http_reqs...............................................................: 1943   9.2498/s
    
        EXECUTION
        iteration_duration......................................................: avg=47.57s min=15.06s  med=41.27s max=2m41s  p(90)=1m30s  p(95)=1m54s
        iterations..............................................................: 1613   7.67881/s
        vus.....................................................................: 703    min=6         max=999
        vus_max.................................................................: 1000   min=1000      max=1000
    
        NETWORK
        data_received...........................................................: 1.0 GB 5.0 MB/s
        data_sent...............................................................: 5.3 MB 25 kB/s
    
        WEBSOCKET
        ws_connecting...........................................................: avg=7.63s  min=14.11ms med=4.83s  max=31.09s p(90)=21.55s p(95)=29.83s
        ws_msgs_received........................................................: 532254 2533.835917/s
        ws_msgs_sent............................................................: 49229  234.358424/s
        ws_session_duration.....................................................: avg=46.53s min=10.1s   med=41.2s  max=2m41s  p(90)=1m30s  p(95)=1m54s
        ws_sessions.............................................................: 2308   10.987411/s
    
    running (3m30.1s), 0000/1000 VUs, 1612 complete and 697 interrupted iterations
    default ✓ [======================================] 0702/1000 VUs  3m0s
    ```
    

|  설정 \ 배치 사이즈 | 10 | 20 | 100 |
| --- | --- | --- | --- |
| 기본 | 7.607943/s | 6.679315/s |  |
| @Async |  | 11.898071/s | 10.512297/s |

그 결과 배치사이즈 20일 때, 최고의 TPS 지표가 도출되는 것을 확인했다.

결론적으로 채팅 쓰기 및 읽기 시나리오의 TPS 지표를 6.7/s에서 11.9/s로 약 77% 향상되었다.

## 6. 한계점

현재 Spring Data JPA의 saveAll(List<T>)을 사용하고 있다. 그런데 저장되는 컬렉션의 모든 요소들에 대해 INSERT 쿼리가 발생하는 것을 확인했다.

이는 힙 메모리 접근이 많아지면서 많은 데이터베이스 연산 비용이 발생할 수 있다고 판단했다.

그를 위해 JPA에서 제공하는 배치 저장을 사용하려고 했다.

그러나 제대로 작동하지 않는 문제가 발생했고, 그 원인이 @Async의 사용임을 알게되었다.

배치 저장은 하나의 트랜잭션 내에서만 작동을 하기 때문에, 별도의 스레드에 위임하는 해당 어노테이션 사용 시 배치 저장 사용이 불가능하다.

따라서, 이는 @Async 사용 시 발생하는 트레이드 오프라고 생각했지만, TPS가 향상됨에 따라 사용하는 면이 훨씬 이득이라고 판단했다.

# 🔥 트러블 슈팅

## 1. 간헐적으로 접속하자마자 Disconnected되는 문제

WS로 접속 후 ENTER 메시지를 전송하면 바로 Disconnected되는 문제가 발생했다. 리액트 코드에선 websocket.send()를 통해 전송되기 때문에 에러가 발생할 만한 코드가 존재하지 않았다.

### 문제 원인

현재 백엔드에선 채팅방(ChatRoom)에서 연결된 세션들을 Set<WebSocketSession>으로 관리하고 있고, handler가 메시지를 받으면 각 세션에게 Send하는 방식으로 작동한다.

그런데 Disconnected될 경우, 해당 Set에서 세션을 제거하는 코드가 빠져있었고, 이 때문에 연결되지 않은 세션에 메시지를 전송하여 예외가 발생한 것이있더.

```java
@Override
protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
    String payload = message.getPayload();
    ChatMessage chatMessage = objectMapper.readValue(payload, ChatMessage.class);
    ChatRoom room = chatService.findRoomById(chatMessage.getRoomId());
    Set<WebSocketSession> sessions = room.getSessions();

    if (chatMessage.getType().equals(MessageType.ENTER)) {
        sessions.add(session);
        chatMessage.setMessage(chatMessage.getSender() + "님이 입장했습니다.");
        sendToEachSocket(sessions,new TextMessage(objectMapper.writeValueAsString(chatMessage)));
    } else if (chatMessage.getType().equals(MessageType.QUIT)) {
        sessions.remove(session);
        chatMessage.setMessage(chatMessage.getSender() + "님이 퇴장했습니다..");
        sendToEachSocket(sessions,new TextMessage(objectMapper.writeValueAsString(chatMessage)));
    } else {
        sendToEachSocket(sessions,message);
    }

    Long chatId = chatService.saveTextMessage(chatMessage);
    log.info("저장 완료 chat Id : {}",chatId);
}

private void sendToEachSocket(Set<WebSocketSession> sessions, TextMessage message){
    sessions.parallelStream().forEach(roomSession -> {
        try {
            roomSession.sendMessage(message);
        } catch (IOException e) {
            log.error(e.getMessage());
            throw new RuntimeException(e);
        }
    });
}
```

해당 문제는 강제 종료 시에 발생하는 것을 확인했다. 그 이유는 QUIT 메시지를 클라이언트에게 받았을 때 remove를 하도록되어 있기 때문에 강제 종료 시에는 작동하지 않았다.

### 해결

따라서, `TextWebSocketHandler` 에서 제공하는 메서드 중 disconnected됐을 경우 실행되는 메서드를 오버라이딩하여 수정했다.

```java
@Override
public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
    ChatRoom room = chatService.findRoomById(ChatRoom.roomId);
    Set<WebSocketSession> sessions = room.getSessions();
    sessions.remove(session);
}
```
